### PR TITLE
Nest Facility flows under Facility > Facility

### DIFF
--- a/versioned_docs/version-3.1/concepts/facility/facility.mdx
+++ b/versioned_docs/version-3.1/concepts/facility/facility.mdx
@@ -103,7 +103,7 @@ Note: When you create a facility, Care creates a default Administration departme
 
 ## Related
 
-- Flow: [Create a facility](../../flows/facility/create-facility.mdx)
-- Flow: [View a facility](../../flows/facility/view-facility.mdx)
-- Flow: [Update facility details](../../flows/facility/update-facility-details.mdx)
-- Flow: [Delete a facility](../../flows/facility/delete-facility.mdx)
+- Flow: [Create a facility](../../flows/facility/facility/create-facility.mdx)
+- Flow: [View a facility](../../flows/facility/facility/view-facility.mdx)
+- Flow: [Update facility details](../../flows/facility/facility/update-facility-details.mdx)
+- Flow: [Delete a facility](../../flows/facility/facility/delete-facility.mdx)

--- a/versioned_docs/version-3.1/flows/facility/facility/_category_.json
+++ b/versioned_docs/version-3.1/flows/facility/facility/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Facility",
+  "position": 1,
+  "key": "facility-facility-flows"
+}

--- a/versioned_docs/version-3.1/flows/facility/facility/create-facility.mdx
+++ b/versioned_docs/version-3.1/flows/facility/facility/create-facility.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Overview
 
-This flow describes how to create a new [facility](../../concepts/facility/facility.mdx)  in Care.
+This flow describes how to create a new [facility](../../../concepts/facility/facility.mdx)  in Care.
 
 ## Pre-requisites
 
@@ -65,7 +65,7 @@ Select **Create Facility**.
 
 Concepts:
 
-- [Facility](../../concepts/facility/facility.mdx)
+- [Facility](../../../concepts/facility/facility.mdx)
 
 Flows:
 

--- a/versioned_docs/version-3.1/flows/facility/facility/delete-facility.mdx
+++ b/versioned_docs/version-3.1/flows/facility/facility/delete-facility.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 ## Overview
 
-This flow describes how a system administrator deletes a [facility](../../concepts/facility/facility.mdx) in Care.
+This flow describes how a system administrator deletes a [facility](../../../concepts/facility/facility.mdx) in Care.
 
 ## Pre-requisites
 
@@ -42,7 +42,7 @@ Care asks you to type the facility name to confirm. Type the word Delete, then a
 
 Concepts:
 
-- [Facility](../../concepts/facility/facility.mdx)
+- [Facility](../../../concepts/facility/facility.mdx)
 
 Flows:
 

--- a/versioned_docs/version-3.1/flows/facility/facility/update-facility-details.mdx
+++ b/versioned_docs/version-3.1/flows/facility/facility/update-facility-details.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 ## Overview
 
-This flow describes how to change the details and the cover photo of a [facility](../../concepts/facility/facility.mdx) in Care.
+This flow describes how to change the details and the cover photo of a [facility](../../../concepts/facility/facility.mdx) in Care.
 
 ## Pre-requisites
 
@@ -68,7 +68,7 @@ Go back to **Settings**, then **General**. Select **Edit Cover Photo**. Change t
 
 Concepts:
 
-- [Facility](../../concepts/facility/facility.mdx)
+- [Facility](../../../concepts/facility/facility.mdx)
 
 Flows:
 

--- a/versioned_docs/version-3.1/flows/facility/facility/view-facility.mdx
+++ b/versioned_docs/version-3.1/flows/facility/facility/view-facility.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ## Overview
 
-This flow describes how to browse [facilities](../../concepts/facility/facility.mdx) in Care and open one to
+This flow describes how to browse [facilities](../../../concepts/facility/facility.mdx) in Care and open one to
 see its details. Care gives you two ways to do this. You can browse the public
 directory without a sign-in. You can also open a facility from within an organization
 after you sign in.
@@ -87,7 +87,7 @@ below.
 
 Concepts:
 
-- [Facility](../../concepts/facility/facility.mdx)
+- [Facility](../../../concepts/facility/facility.mdx)
 
 Flows:
 

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -46,10 +46,17 @@
           "label": "Facility",
           "key": "facility-flows",
           "items": [
-            "flows/facility/create-facility",
-            "flows/facility/view-facility",
-            "flows/facility/update-facility-details",
-            "flows/facility/delete-facility"
+            {
+              "type": "category",
+              "label": "Facility",
+              "key": "facility-facility-flows",
+              "items": [
+                "flows/facility/facility/create-facility",
+                "flows/facility/facility/view-facility",
+                "flows/facility/facility/update-facility-details",
+                "flows/facility/facility/delete-facility"
+              ]
+            }
           ]
         },
         {


### PR DESCRIPTION
## What

Follow-up to #48. Nests the Facility flows one level deeper so the sidebar reads `Flows > Facility > Facility > …`, matching `Flows > Clinical > Patient` and `Flows > Medications > Medication Request`.

- Moves `flows/facility/*.mdx` to `flows/facility/facility/*.mdx`
- Nests a `Facility` module category inside the `Facility` domain category in the 3.1 sidebar
- Updates the relative links in the flows and in the Facility concept to match the new depth

In #48 these flows sat flat under `flows/facility/`, because the domain and the module have the same name. That made Facility the odd one out next to the other modules.

## Route change

The four flow URLs move:

| Before | After |
| --- | --- |
| `/flows/facility/create-facility` | `/flows/facility/facility/create-facility` |
| `/flows/facility/view-facility` | `/flows/facility/facility/view-facility` |
| `/flows/facility/update-facility-details` | `/flows/facility/facility/update-facility-details` |
| `/flows/facility/delete-facility` | `/flows/facility/facility/delete-facility` |

Nothing in the site links to the old paths, so the build is clean. Worth deciding whether these need redirects, given #48 is already merged and deployed.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
