### PR TITLE
Add Department and Location docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/facility/department.mdx
+++ b/versioned_docs/version-3.1/concepts/facility/department.mdx
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+---
+
+# Department
+
+## Definition
+
+A **[department](https://build.fhir.org/organization.html)** in Care is a group inside a facility, such as a ward, a clinical team, or an administrative unit. A department can hold sub-departments, so the departments of a facility form a hierarchy. Care models a department on the FHIR Organization resource.
+
+Note: Care creates one root department named Administration for every new facility. You cannot create, edit, or delete this root department from the settings screens. You also cannot create a department under it. The person who creates the facility becomes the Facility Admin of the root department.
+
+Note: Your deployment sets the maximum nesting depth and the maximum number of departments for each facility.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the department. This is required. |
+| Description | A description of the department. This is optional. |
+| Type | The kind of department. Select Department or Team. |
+| Parent department | The department that this department sits under. A department with no parent is a top-level department in the facility. |
+| Active | Whether the department is active. |
+
+### Type
+
+Type records the kind of department. You select the type when you create the department, and you can change it later. Care offers these two values:
+
+- Department
+- Team
+
+Note: Care keeps other department types for its own use, such as the root Administration department. Care does not offer these types on the department settings screens.
+
+## Permissions
+
+| Permission | What it allows |
+| --- | --- |
+| Can Create Facility Organizations | Create a new department. The Facility Admin role holds this permission. |
+| Can Manage Facility Organizations | Edit the name, description, and type of a department. The Facility Admin and Administrator roles hold this permission. |
+| Can Delete Facility Organizations | Delete a department. The Facility Admin role holds this permission. |
+| Can List Users in a Facility Organizations | See the members of a department. The Facility Admin, Admin, Staff, Doctor, Administrator, and Nurse roles hold this permission. |
+| Can Manage Users in a Facility Organization | Add a member to a department, remove a member from it, or change the role of a member in it. The Facility Admin and Administrator roles hold this permission. |
+
+Note: A role that you grant on a department also applies to the sub-departments of that department.
+
+## Related
+
+- Flow: [Create a department](../../flows/facility/department/create-department.mdx)
+- Flow: [Update a department](../../flows/facility/department/update-department.mdx)
+- Flow: [Add users to a department](../../flows/facility/department/add-users-to-department.mdx)
+- Flow: [Delete a department](../../flows/facility/department/delete-department.mdx)
+- Concept: [Facility](../../concepts/facility/facility.mdx)

--- a/versioned_docs/version-3.1/concepts/facility/location.mdx
+++ b/versioned_docs/version-3.1/concepts/facility/location.mdx
@@ -2,77 +2,98 @@
 sidebar_position: 4
 ---
 
-# Location
+# Locations
 
-A **location** is a physical place inside a facility where care happens or resources sit — a building, a wing, a ward, a room, or a single bed. Locations form a nested tree that mirrors the real geography of your facility, so the platform can answer questions like "which bed is this patient in?" and "who is allowed into this ward?".
+## Definition
 
-## What it represents
+A **[location](https://build.fhir.org/location.html)** in Care is a physical place inside a facility. A location can be a building, a ward, a room, or a bed. Locations sit inside one another and form a hierarchy. For example, a building contains wards, a ward contains rooms, and a room contains beds.
 
-In Care's FHIR-aligned model, a location maps to the **Location** resource. Each location records:
+## Key Attributes
 
-- **What kind of place it is** — a name, a description, and a physical form such as ward, room, or bed
-- **Where it sits in the tree** — its parent and children, since every place can nest inside a larger one and hold smaller ones, with no fixed limit on depth
-- **Whether it is usable** — and, for beds and rooms, a finer operational state (occupied, unoccupied, housekeeping, contaminated, isolated, closed)
-- **Who is in it** — the encounter, if any, currently occupying the place (most meaningful for a bed)
-- **Who may work there** — the organizations granted access to this part of the facility
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the location. You must enter a name. |
+| Description | A description of the location. This is optional. |
+| Location Form | The type of place that the location represents. You must choose a Location Form when you create the location. You cannot change it later. |
+| Status | The state of the location. You must choose a status. |
+| Operational Status | The current use of the location. You must choose an operational status. |
+| Parent location | The location that this location sits under in the hierarchy. You set the parent location when you create the location. |
+| Order among siblings | The position of the location among the locations under the same parent location. |
+| Organizations | The facility departments that you link to the location. |
+| Availability | Whether the location is Available or Reserved. |
+| Current Encounter | The encounter of the patient who uses this location now. |
 
-A location is a *place*, not a *department* or a *team*. A ward as a physical space is a location; the unit of staff and responsibility that runs it is an [organization](../access-governance/organization.mdx). The two are linked, but they are different primitives — you nest places inside places, and you grant an organization access to a place.
+### Location Form
 
-## Classification
+The Location Form tells Care what type of place the location is. Choose one of these forms:
 
-Two attributes describe what a location *is*, and they are fixed when it is created.
+- Site
+- Building
+- Wing
+- Ward
+- Level
+- Corridor
+- Room
+- Bed
+- Vehicle
+- House
+- Cabinet
+- Road
+- Area
+- Jurisdiction
+- Virtual
 
-- **Mode** separates a *kind* of place from a concrete *instance* of one. A `kind` is a class of location — "a ward", "a building" — and can contain children. An `instance` is one specific place — "Bed 12", "Room 4" — and is a leaf: instances cannot have children.
-- **Form** is the physical type, drawn from a standard FHIR list: site, building, wing, ward, level, corridor, room, bed, vehicle, house, and more. This is what lets a deployment model the difference between a wing and the beds inside it.
+### Parent location and hierarchy
 
-Beds are not a separate concept in Care — a bed is simply a location whose form is `bed` and whose mode is `instance`. The whole facility map, from building down to bed, is one uniform tree.
+A location with no parent location is a top-level location for the facility. Only some Location Forms can hold child locations. A Ward can hold child locations. A Bed cannot hold child locations.
 
-## Lifecycle
+Note: You must choose a parent location before you create a Bed.
 
-A location's own status is deliberately simple — it describes whether the place exists and is usable, not whether someone is in it.
+Note: Your deployment sets the limit for the depth of the hierarchy. Your deployment also sets the limit for the total number of locations in one facility.
 
-```text
-active → inactive
-        (unknown)
-```
+You can change the order of the locations under the same parent location. See [Reorder locations](../../flows/facility/location/reorder-locations.mdx).
 
-- **active** — the location is live and can be used for encounters and assignments
-- **inactive** — retired from routine use but kept for history; it does not disappear
-- **unknown** — status has not been determined
+### Organizations
 
-Separately, beds and rooms carry an **operational status** that changes far more often: occupied, unoccupied, housekeeping, contaminated, isolated, or closed. This is the day-to-day signal a bed-management board reads, and it is distinct from the location simply being `active`.
+Organizations are the facility departments that you link to the location. The linked departments control which members can access the location. See [Manage a location's organizations](../../flows/facility/location/manage-location-organizations.mdx).
 
-## How it connects
+### Availability
 
-Locations are the spatial backbone that other primitives attach to.
+Care sets the availability of the location. The location is Reserved when a patient is assigned to it. In all other cases the location is Available. You cannot set the availability yourself.
 
-- **Encounters** occupy locations over time. When a patient is admitted to a bed, a record captures *which* place, *when* occupancy began, and *whether* it is planned, active, reserved, or completed. From these records the platform derives a location's current encounter and whether it is free or reserved — which is how a bed knows it is taken.
-- **Organizations** are granted access to locations. Giving a [facility organization](../access-governance/facility-organization.mdx) access to a ward lets every user under that organization work in the ward and its descendants, through the role they hold. Access flows *downward*: grant it at the building and it reaches every room and bed inside.
-- **Facility** owns the whole tree. Every location belongs to exactly one [facility](../facility/facility.mdx), and the root of its tree sits at the facility level.
+## Status
 
-One important consequence of the tree: access and other inherited properties cascade to descendants asynchronously. When you change who can reach a ward, the rooms and beds beneath it settle a moment later rather than instantly — expect it to be eventually consistent, not immediate.
+| Status | Description |
+| --- | --- |
+| Active | The facility uses the location. |
+| Inactive | The facility does not use the location. |
+| Unknown | The state of the location is not known. |
+
+## Operational Status
+
+| Operational Status | Description |
+| --- | --- |
+| Closed | The location is closed for use. |
+| Housekeeping | Housekeeping staff prepare the location. |
+| Occupied | A patient uses the location. |
+| Unoccupied | No patient uses the location. |
+| Isolated | The location is under isolation. |
+| Contaminated | The location is contaminated. |
 
 ## Permissions
 
-Access to locations is governed by facility-level permissions. Viewing the location tree is open to most clinical roles; changing the tree or its access grants is reserved for administrators and senior staff.
+| Permission | What it allows |
+| --- | --- |
+| Can List Facility Locations | View locations. |
+| Can Create/Update Facility Locations | Create, edit, reorder, and delete locations. |
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_facility_locations` | Create, edit, or delete a location, and add or remove an organization's access to one (add a ward, room, or bed; change status; grant org access) | Facility Admin, Admin, Staff |
-| `can_create_facility_organization` | Create a root location (one with no parent) at the top of the facility tree | Facility Admin |
-| `can_list_facility_locations` | View a facility's locations, the location tree, and which organizations have access to a location | Admin, Doctor, Facility Admin, Administrator, Nurse, Staff, Pharmacist |
-| `can_manage_facility_organization` | Grant or change an organization's access to a location | Facility Admin, Administrator |
-| `can_write_encounter` | Assign or move an encounter (a patient) to a location, such as placing them in a bed | Admin, Doctor, Nurse, Facility Admin |
-
-Roles are granted through facility and organization memberships, and because location access follows the tree, a permission held at a parent location cascades down to everything nested beneath it.
+Note: To manage the organizations of a location, you also need permission to manage the facility department that you link or unlink.
 
 ## Related
 
-- Reference: [Location (technical)](../../references/facility/location.mdx)
-- Concept: [Facility](../facility/facility.mdx)
-- Concept: [Facility organization](../access-governance/facility-organization.mdx)
-- Concept: [Encounter](../clinical/encounter.mdx)
-
-## FHIR reference
-
-Care's location aligns with the FHIR [Location](https://build.fhir.org/location.html) resource, including its mode (`kind` / `instance`), physical-form codes, and operational-status codes for beds and rooms.
+- Flow: [Create a location](../../flows/facility/location/create-location.mdx)
+- Flow: [View locations](../../flows/facility/location/view-locations.mdx)
+- Flow: [Edit a location](../../flows/facility/location/edit-location.mdx)
+- Flow: [Reorder locations](../../flows/facility/location/reorder-locations.mdx)
+- Flow: [Delete a location](../../flows/facility/location/delete-location.mdx)
+- Flow: [Manage a location's organizations](../../flows/facility/location/manage-location-organizations.mdx)

--- a/versioned_docs/version-3.1/flows/facility/department/_category_.json
+++ b/versioned_docs/version-3.1/flows/facility/department/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Department",
+  "position": 2,
+  "key": "facility-department-flows"
+}

--- a/versioned_docs/version-3.1/flows/facility/department/add-users-to-department.mdx
+++ b/versioned_docs/version-3.1/flows/facility/department/add-users-to-department.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 3
+---
+
+# Add users to a department
+
+## Overview
+
+This flow describes how to manage the members of a [department](../../../concepts/facility/department.mdx) in Care. You can add a user, change a member's role, and remove a member.
+
+## Pre-requisites
+
+- The department is set up in the facility.
+- The user has an account in Care. If the user has no account, you can create the account during this flow.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can List Users in a Facility Organizations | Lets you view the members of a department. Facility Admin, Admin, Staff, Doctor, Administrator, and Nurse hold this permission. |
+| Can Manage Users in a Facility Organization | Lets you add a member, change a member's role, or remove a member. Facility Admin and Administrator hold this permission. |
+
+Note: You cannot give a member a role that carries more permissions than your own effective permissions on that department and its parent departments. Care blocks the attempt.
+
+## Steps
+
+### 1. Open the Users tab of the department
+
+Open the facility. Select Settings. Select Departments. Open the department. Select the Users tab.
+
+### 2. Add a user to the department
+
+Select Link User. Search for the user. Select the user. Under Select Role, select a role. Select Add to Organization.
+
+Note: To link a service account, select the Service accounts tab. Then select Link Service Account.
+
+Note: If the user has no account in Care, select Add User. Complete the user form. Care then opens the Link User form with the new user selected.
+
+### 3. Change a member's role
+
+Find the member in the list. Select Edit next to the member's name. Care opens the Edit User Role sheet. Under Select New Role, select the new role. Select Update Role.
+
+Note: You must select a role different from the member's current role.
+
+Note: Care blocks a role change that removes the last Facility Admin from the facility's root department.
+
+### 4. Remove a member
+
+Find the member in the list. Select Edit next to the member's name. In the sheet that opens, select Remove User. Select Remove to confirm.
+
+Note: Care blocks the removal of the last member of the facility's root department.
+
+## Expected Outcome
+
+- Care shows the new member in the Users tab of the department, with the role of the member.
+- Care shows a success message when you add a member, change a member's role, or remove a member.
+- Care removes the member from the list when you remove the member.
+
+## Related
+
+Concepts:
+
+- [Department](../../../concepts/facility/department.mdx)
+
+Flows:
+
+- [Create a department](./create-department.mdx)
+- [Update a department](./update-department.mdx)

--- a/versioned_docs/version-3.1/flows/facility/department/create-department.mdx
+++ b/versioned_docs/version-3.1/flows/facility/department/create-department.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 1
+---
+
+# Create a department
+
+## Overview
+
+This flow describes how to create a new [department](../../../concepts/facility/department.mdx) in a facility in Care.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- If you create the department under an existing department (a sub-department), open that parent department first.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Facility Organizations | Lets you create a department. Held by Facility Admin. |
+
+## Steps
+
+### 1. Open the departments settings
+
+Open the facility. Select Settings. Select Departments.
+
+### 2. Start the new department
+
+To create a top-level department, select Add Department/Team from the Departments list.
+
+To create a sub-department, open the parent department first. Then select Add Department/Team on the page of that department.
+
+Note: You cannot create a department under the root Administration department.
+
+### 3. Complete the form
+
+Care opens the Create Department/Team form.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the department. Required. |
+| Type | Choose Department or Team. |
+| Description | A description of the department. Optional. |
+
+Note: Care does not accept a duplicate department name. The name must be different from the names of the other departments at the same level under the same top-level department.
+
+Note: Your deployment sets a maximum nesting depth. Your deployment also sets a maximum total number of departments per facility. If you reach either limit, Care blocks the creation.
+
+### 4. Save the department
+
+Select Create Organization.
+
+## Expected Outcome
+
+- Care creates the department under the facility, or under the parent department you selected.
+- Care shows a success message.
+
+## Related
+
+Concepts:
+
+- [Department](../../../concepts/facility/department.mdx)
+
+Flows:
+
+- [Update a department](./update-department.mdx)
+- [Add users to a department](./add-users-to-department.mdx)

--- a/versioned_docs/version-3.1/flows/facility/department/delete-department.mdx
+++ b/versioned_docs/version-3.1/flows/facility/department/delete-department.mdx
@@ -1,0 +1,56 @@
+---
+sidebar_position: 4
+---
+
+# Delete a department
+
+## Overview
+
+This flow describes how to delete a [department](../../../concepts/facility/department.mdx) from a facility in Care.
+
+## Pre-requisites
+
+- The department is set up in the facility.
+- The department has no sub-departments. If the department has sub-departments, delete them first.
+- The department has no members other than you.
+- The department is not linked to any encounter, location, or device.
+- The department is not the facility's root department ("Administration"). Care does not let you delete the root department.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Delete Facility Organizations | Lets you delete a department. Held by Facility Admin. |
+
+## Steps
+
+### 1. Open the department list
+
+Open the facility. Select Settings. Select Departments.
+
+### 2. Start the deletion
+
+Find the department you want to delete. Select the delete action (a trash icon).
+
+Note: Care shows this action only when the department has no sub-departments.
+
+### 3. Confirm the deletion
+
+Care opens a confirmation dialog. Select Remove.
+
+## Expected Outcome
+
+- Care deletes the department.
+- The department no longer appears in the list.
+
+## Related
+
+Concepts:
+
+- [Department](../../../concepts/facility/department.mdx)
+
+Flows:
+
+- [Create a department](./create-department.mdx)
+- [Update a department](./update-department.mdx)

--- a/versioned_docs/version-3.1/flows/facility/department/update-department.mdx
+++ b/versioned_docs/version-3.1/flows/facility/department/update-department.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_position: 2
+---
+
+# Update a department
+
+## Overview
+
+This flow describes how to change the name, description, or type of an existing [department](../../../concepts/facility/department.mdx) in Care.
+
+## Pre-requisites
+
+- The department is set up in the facility.
+- The department is not the facility's root department ("Administration"). Care does not let you edit the root department.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Facility Organizations | Lets you edit a department. Facility Admin and Administrator hold this permission. |
+
+## Steps
+
+### 1. Open the department
+
+Open the facility. Select Settings. Select Departments. Find the department in the list.
+
+### 2. Start the edit
+
+On a large screen, select the pencil icon in the Actions column. On a small screen, select Edit on the card of the department.
+
+Care opens the Edit Department/Team form. The form shows the current details of the department.
+
+### 3. Update the details
+
+Change the fields you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the department. |
+| Type | The type of the group: Department or Team. |
+| Description | The description of the department. |
+
+### 4. Save your changes
+
+Select Update Organization.
+
+## Expected Outcome
+
+- Care saves the new details of the department.
+- The department list shows the updated details.
+
+## Related
+
+Concepts:
+
+- [Department](../../../concepts/facility/department.mdx)
+
+Flows:
+
+- [Create a department](./create-department.mdx)
+- [Delete a department](./delete-department.mdx)

--- a/versioned_docs/version-3.1/flows/facility/location/_category_.json
+++ b/versioned_docs/version-3.1/flows/facility/location/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Location",
+  "position": 3,
+  "key": "facility-location-flows"
+}

--- a/versioned_docs/version-3.1/flows/facility/location/create-location.mdx
+++ b/versioned_docs/version-3.1/flows/facility/location/create-location.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 1
+---
+
+# Create a location
+
+## Overview
+
+This flow describes how to add a new [location](../../../concepts/facility/location.mdx) to a facility in Care.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- If you create a Bed, select a parent location first. Care does not create a Bed without a parent location.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create/Update Facility Locations | Lets you create a location under an existing location and update locations. |
+
+Note: To create a top-level location, which has no parent location, you need a different permission. That permission covers the management of the facility's departments.
+
+## Steps
+
+### 1. Open the locations settings
+
+1. Open the facility.
+2. Select **Settings**.
+3. Select **Locations**.
+
+### 2. Start a new location
+
+Select **Add Location**.
+
+### 3. Choose the location form
+
+Choose the Location Form. The Location Form is the type of place, for example Building, Ward, Room, or Bed.
+
+Note: You cannot change the Location Form after you create the location.
+
+### 4. Create multiple beds (optional)
+
+This step applies only if you choose Bed and select a parent location.
+
+1. Turn on **Create Multiple Beds**.
+2. Choose how many beds to create. The count is from 2 to 15.
+3. Keep the default names. Care names each bed with the parent location's name and a number.
+4. To set each name yourself, turn on **Customize Names**. Then enter a name for each bed.
+
+### 5. Enter the location details
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the location. This field is mandatory. |
+| Description | More information about the location. This field is optional. |
+| Status | The status of the location. The default value is Active. |
+| Operational Status | The operational status of the location. The default value is Unoccupied. |
+
+### 6. Save the location
+
+Select **Add Location**.
+
+## Expected Outcome
+
+- Care creates the location in the facility.
+- If you create multiple beds, Care creates each bed under the parent location.
+
+## Related
+
+Concepts:
+
+- [Locations](../../../concepts/facility/location.mdx)
+
+Flows:
+
+- [View locations](./view-locations.mdx)
+- [Edit a location](./edit-location.mdx)

--- a/versioned_docs/version-3.1/flows/facility/location/delete-location.mdx
+++ b/versioned_docs/version-3.1/flows/facility/location/delete-location.mdx
@@ -1,0 +1,58 @@
+---
+sidebar_position: 5
+---
+
+# Delete a location
+
+## Overview
+
+This flow describes how to delete a [location](../../../concepts/facility/location.mdx) from a facility in Care.
+
+## Pre-requisites
+
+- The location is set up in the facility.
+- The location has no child locations.
+- No patient is assigned to the location.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create/Update Facility Locations | Lets you create, update, and delete locations in the facility. |
+
+## Steps
+
+### 1. Open the location list
+
+Go to the location list of the facility. See [View locations](./view-locations.mdx).
+
+### 2. Select the delete action
+
+Find the location that you want to delete.
+
+Select the delete action for that location.
+
+Note: Care shows the delete action only when the location has no child locations and no assigned patient.
+
+Note: If the location has child locations, delete them first. Care does not delete a location that still has child locations.
+
+### 3. Confirm the deletion
+
+Confirm the deletion.
+
+## Expected Outcome
+
+- Care deletes the location.
+- The location list no longer shows the location.
+
+## Related
+
+Concepts:
+
+- [Locations](../../../concepts/facility/location.mdx)
+
+Flows:
+
+- [View locations](./view-locations.mdx)
+- [Edit a location](./edit-location.mdx)

--- a/versioned_docs/version-3.1/flows/facility/location/edit-location.mdx
+++ b/versioned_docs/version-3.1/flows/facility/location/edit-location.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+---
+
+# Edit a location
+
+## Overview
+
+This flow describes how to change the details of a [location](../../../concepts/facility/location.mdx) in a facility.
+
+## Pre-requisites
+
+- The location is set up in the facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create/Update Facility Locations | Lets you create locations in a facility and update their details. |
+
+## Steps
+
+### 1. Open the location you want to change
+
+Go to the location list, card, or table view. See [View locations](./view-locations.mdx).
+
+You can also open the detail page of the location.
+
+### 2. Select the edit action
+
+Select the edit action on the location. Care opens the same form that you use to create a location. The form shows the current details of the location.
+
+Note: You cannot change the Location Form here. The Location Form stays fixed after you create the location.
+
+### 3. Update the details
+
+Change the details that you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the location. |
+| Description | More information about the location. |
+| Status | The status of the location. |
+| Operational Status | The operational status of the location. |
+
+### 4. Save your changes
+
+Save the form.
+
+Note: You cannot move a location under a different parent location after you create it. You can only change the position of the location among its current sibling locations. See [Reorder locations](./reorder-locations.mdx).
+
+## Expected Outcome
+
+- Care saves the new details of the location.
+- The location list shows the updated details.
+
+## Related
+
+Concepts:
+
+- [Locations](../../../concepts/facility/location.mdx)
+
+Flows:
+
+- [Create a location](./create-location.mdx)
+- [View locations](./view-locations.mdx)
+- [Reorder locations](./reorder-locations.mdx)

--- a/versioned_docs/version-3.1/flows/facility/location/manage-location-organizations.mdx
+++ b/versioned_docs/version-3.1/flows/facility/location/manage-location-organizations.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_position: 6
+---
+
+# Manage a location's organizations
+
+## Overview
+
+This flow describes how to link facility departments to a [location](../../../concepts/facility/location.mdx). The linked departments control which members can access the location.
+
+## Pre-requisites
+
+- The location is set up in the facility. See [View locations](./view-locations.mdx).
+- The facility department that you link or unlink is set up in the facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create/Update Facility Locations | Lets you link and unlink departments on the location. |
+
+Note: You also need the permission to manage the facility department that you link or unlink.
+
+## Steps
+
+### 1. Open the location
+
+Open the location's detail page. See [View locations](./view-locations.mdx).
+
+### 2. Open the organization list
+
+Select **Manage Organization(s)**. Care shows the departments that are linked to this location.
+
+### 3. Link a department
+
+Select a department to link it to the location. The members of that department get access to the location.
+
+### 4. Unlink a department
+
+Remove a linked department from the list. The members of that department lose access to the location.
+
+## Expected Outcome
+
+- Care shows the updated list of departments that are linked to the location.
+- The members of the linked departments can access the location.
+
+## Related
+
+Concepts:
+
+- [Locations](../../../concepts/facility/location.mdx)
+
+Flows:
+
+- [View locations](./view-locations.mdx)
+- [Edit a location](./edit-location.mdx)

--- a/versioned_docs/version-3.1/flows/facility/location/reorder-locations.mdx
+++ b/versioned_docs/version-3.1/flows/facility/location/reorder-locations.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_position: 4
+---
+
+# Reorder locations
+
+## Overview
+
+This flow describes how to change the order of a [location](../../../concepts/facility/location.mdx) among its sibling locations in Care.
+
+## Pre-requisites
+
+- The location and its sibling locations are set up under the same parent location.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create/Update Facility Locations | Lets you change the order of locations in a facility. |
+
+## Steps
+
+### 1. Open the location list
+
+Open the location list in the table view or the card view. See [View locations](./view-locations.mdx).
+
+### 2. Find the location to move
+
+Find the location that you want to move.
+
+### 3. Move the location
+
+Select the up arrow to move the location earlier among its sibling locations.
+
+Select the down arrow to move the location later among its sibling locations.
+
+Care swaps the position of the location with the sibling location directly above or below it.
+
+Note: If the move takes the location past the edge of the current page of results, Care opens the neighboring page to complete the move.
+
+Note: Reordering changes the position of a location among its current sibling locations only. You cannot move the location under a different parent location.
+
+## Expected Outcome
+
+- The location shows in its new position among its sibling locations.
+
+## Related
+
+Concepts:
+
+- [Locations](../../../concepts/facility/location.mdx)
+
+Flows:
+
+- [View locations](./view-locations.mdx)
+- [Edit a location](./edit-location.mdx)

--- a/versioned_docs/version-3.1/flows/facility/location/view-locations.mdx
+++ b/versioned_docs/version-3.1/flows/facility/location/view-locations.mdx
@@ -1,0 +1,72 @@
+---
+sidebar_position: 2
+---
+
+# View locations
+
+## Overview
+
+This flow describes how to browse the [locations](../../../concepts/facility/location.mdx) of a facility in Care. It also describes how to open one location and see its details.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- The facility has at least one location.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can List Facility Locations | Lets you see the locations of the facility and their details. |
+
+## Steps
+
+### 1. Open the locations list
+
+1. Open the facility.
+2. Select **Settings**.
+3. Select **Locations**.
+
+### 2. Browse the locations
+
+1. Select the **List** tab.
+2. Care shows the locations of the facility as a table or as cards.
+3. Use the tree at the side of the list to move through the hierarchy.
+4. Select a top-level location in the tree to see its child locations.
+5. Continue to select child locations to go deeper in the hierarchy.
+
+### 3. See the locations on a map
+
+1. Select the **Map** tab.
+2. Care shows the locations on a map.
+
+### 4. Open the details of a location
+
+1. Select a location.
+2. Care shows the breadcrumb trail of the parent locations of the selected location.
+3. Care shows the name, the Location Form, and the status of the location.
+
+Note: If the Location Form of the location can hold child locations, Care shows those child locations on this page. A location with the Location Form Bed cannot hold child locations.
+
+Note: To add a location directly below the open location, select **Add Location**.
+
+## Expected Outcome
+
+- Care shows the locations of the facility in a list, in a tree, or on a map.
+- Care shows the name, the Location Form, and the status of the location that you select.
+- Care shows the child locations of the location that you select, if that location can hold child locations.
+
+## Related
+
+Concepts:
+
+- [Locations](../../../concepts/facility/location.mdx)
+
+Flows:
+
+- [Create a location](./create-location.mdx)
+- [Edit a location](./edit-location.mdx)
+- [Reorder locations](./reorder-locations.mdx)
+- [Delete a location](./delete-location.mdx)
+- [Manage a location's organizations](./manage-location-organizations.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -71,6 +71,30 @@
                 "flows/facility/facility/update-facility-details",
                 "flows/facility/facility/delete-facility"
               ]
+            },
+            {
+              "type": "category",
+              "label": "Department",
+              "key": "facility-department-flows",
+              "items": [
+                "flows/facility/department/create-department",
+                "flows/facility/department/update-department",
+                "flows/facility/department/add-users-to-department",
+                "flows/facility/department/delete-department"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Location",
+              "key": "facility-location-flows",
+              "items": [
+                "flows/facility/location/create-location",
+                "flows/facility/location/view-locations",
+                "flows/facility/location/edit-location",
+                "flows/facility/location/reorder-locations",
+                "flows/facility/location/delete-location",
+                "flows/facility/location/manage-location-organizations"
+              ]
             }
           ]
         },


### PR DESCRIPTION
## What

Publishes the **Department** and **Location** documentation from `care_docs` into the docs site (version 3.1).

### Department (new)

- New concept at `concepts/facility/department.mdx`
- Four flows under `flows/facility/department/`:
  1. Create a department
  2. Update a department
  3. Add users to a department
  4. Delete a department

### Location

- Replaces the existing `concepts/facility/location.mdx` with the authored version
- Six flows under `flows/facility/location/`:
  1. Create a location
  2. View locations
  3. Edit a location
  4. Reorder locations
  5. Delete a location
  6. Manage a location's organizations

Both sit as sibling module categories under `Flows > Facility`, beside the existing `Facility` module.

## Notes for reviewers

- The Location concept is **replaced**, not extended. The authored version covers Definition, Key Attributes, the location hierarchy, Permissions and Related.
- The Location concept page keeps the authored title "Locations" while the file and route stay singular (`location`), matching the sibling concepts Facility, Device and Healthcare Service.
- Department is new; it did not previously exist as a concept page. Note that Care models departments as facility organizations, so it sits alongside the existing `concepts/access-governance/facility-organization.mdx`.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
