### PR TITLE
Add Device, Healthcare Service and Resource Request docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/facility/device.mdx
+++ b/versioned_docs/version-3.1/concepts/facility/device.mdx
@@ -4,71 +4,80 @@ sidebar_position: 6
 
 # Device
 
-A **device** in Care is a piece of equipment a facility owns and tracks — a ventilator, an infusion pump, a monitor, a camera. The record is the platform's durable answer to three questions: what equipment exists, where it sits right now, and which patient encounter it is supporting.
+## Definition
 
-## What it represents
+A **[device](https://build.fhir.org/device.html)** in Care is a piece of equipment that a facility owns or uses, for example a ventilator or a monitor. Care tracks where a device is, which department manages it, its status, and its maintenance history.
 
-In Care's FHIR-aligned model, a device maps to the **Device** resource. It holds the things you'd find on an asset register — names and identifiers, manufacturer and model, serial and lot numbers, manufacture and expiry dates — alongside the live picture of where the device is and what it is doing.
+## Key Attributes
 
-A device is the instrument, not a reading from it. The values a monitor produces are stored as observations on an encounter; the device record tracks the instrument itself across every location and patient it touches over its working life. One device, many encounters — the record is what keeps that history coherent.
+| Components | What it captures |
+| --- | --- |
+| Registered Name | The name Care uses to identify the device. This is required. |
+| User Friendly Name | A more familiar name for the device. This is optional. |
+| Identifier | An identifier for the device, for example an inventory tag. This is optional. |
+| Manufacturer | The maker of the device. This is optional. |
+| Manufacture Date | When the device was made. This cannot be a future date. This is optional. |
+| Expiration Date | When the device expires. This must be after the manufacture date. This is optional. |
+| Lot Number | The lot number of the device. This is optional. |
+| Serial Number | The serial number of the device. This is optional. |
+| Model Number | The model number of the device. This is optional. |
+| Part Number | The part number of the device. This is optional. |
+| Contact Points | Phone numbers, emails, or other contact details for the device, for example a vendor support line. This is optional. |
+| Status | Whether the device is Active, Inactive, or Entered in Error. |
+| Availability Status | Whether the device is Available, Lost, Damaged, or Destroyed. |
+| Location | The location that currently holds the device. |
+| Managing Organization | The department that is responsible for the device. |
 
-## Status
+### Contact Points
 
-A device carries two status dimensions that move independently, so it can be in service yet temporarily out of action.
+Each contact point has a type and a value. Care offers these types:
 
-**Operational status** says whether the device is in service:
+- Phone
+- Fax
+- SMS
+- Email
+- URL
+- Pager
+- Other
 
-- **Active** — in service and usable
-- **Inactive** — not currently in service
-- **Entered in error** — the record was created by mistake and should be disregarded
+### Location and Managing Organization
 
-**Availability status** describes its physical condition:
+You do not set the location or the managing organization on the create form or the edit form. You set them separately. See the [Link a device to a location and a department](../../flows/facility/device/link-device-location-department.mdx) flow.
 
-- **Available** — can be located and used
-- **Lost** — cannot be found
-- **Damaged** — needs repair before use
-- **Destroyed** — no longer usable
+Note: Care keeps a history of every location that the device has been in. You see this history when you associate or change the location. Care also keeps a history of the encounters that used the device. You see this history when you select **View History** next to the **Encounter** row. You link a device to an encounter from the **Devices** tab of the encounter, not from the page of the device.
 
-Keeping these separate means a working device that has gone missing reads as *active but lost* — accurate, rather than forcing a single status to mean two things.
+### Status
 
-## How it connects
+| Status | Description |
+| --- | --- |
+| Active | The device is in active use. |
+| Inactive | The device is not in active use. |
+| Entered in Error | Someone added the device by mistake. |
 
-A device moves through a facility, and Care records that journey as history rather than overwriting it:
+### Availability Status
 
-- **Facility** — every device belongs to exactly one owning facility, set from context rather than chosen on each edit.
-- **Managing organization** — the team accountable for the device. This also decides who can see and manage it, through the organization hierarchy.
-- **Current location** — where the device sits today. Moving it closes the old placement and opens a new one, leaving an auditable trail of everywhere it has been.
-- **Current encounter** — the patient encounter the device is actively supporting. Attaching and detaching follow the same close-then-open pattern; when an encounter is completed, its devices are released automatically.
+Availability Status records the physical condition of the device. Care offers these values:
 
-Because placements and encounter links are kept as history, you can always answer "where was this last week?" or "which patients did it serve?" — not just where it is now.
-
-## Types
-
-A device can carry an optional **type** that connects it to a registered plugin for behaviour beyond plain inventory tracking — the bundled example is a `camera`. The type is chosen at creation and cannot change afterward; deployments register their own through the device-type registry. A device with no type is still fully tracked; it simply has no specialised behaviour attached.
+- Available. The device is not lost, not damaged, and not destroyed.
+- Lost
+- Damaged
+- Destroyed
 
 ## Permissions
 
-Access to devices is governed by facility-scoped permissions.
-
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_manage_devices` | Create devices, and update, delete, relocate, service, or change the managing organization of existing ones | Staff, Admin, Facility Admin, Pharmacist |
-| `can_list_devices` | View devices registered to a facility and their location, encounter, and service history | Staff, Admin, Doctor, Nurse, Facility Admin, Pharmacist |
-| `can_manage_device_associations_to_encounters` | Attach a device to or detach it from a patient encounter | Staff, Admin, Doctor, Nurse, Facility Admin |
-| `can_write_encounter` | Also required on the target encounter when attaching a device to it | Admin, Doctor, Nurse, Facility Admin |
-| `can_write_facility_locations` | Also required on the target location when placing a device there | Facility Admin, Admin, Staff |
-| `can_manage_facility_organization` | Also required on the organization when setting or clearing a device's managing organization | Facility Admin, Administrator |
-
-Roles are granted through facility and organization memberships, and they cascade down the organization tree — a user's access to a device follows from the managing organization it sits under.
+| Permission | What it allows |
+| --- | --- |
+| Can List Devices on Facility | View devices and their details. The Staff, Admin, Doctor, Nurse, Facility Admin, and Pharmacist roles hold this permission. |
+| Can Manage Devices on Facility | Create, edit, and delete a device. Link a device to a location or a department. Add or edit the service history of a device. The Staff, Admin, Facility Admin, and Pharmacist roles hold this permission. |
+| Can Manage Device Associations to Encounters | Link a device to an encounter, or unlink it. You do this from the encounter. The Staff, Admin, Doctor, Nurse, and Facility Admin roles hold this permission. |
 
 ## Related
 
-- Reference: [Device (technical)](../../references/facility/device.mdx)
-- Concept: [Facility](../facility/facility.mdx)
-- Concept: [Location](../facility/location.mdx)
-- Concept: [Encounter](../clinical/encounter.mdx)
-- Concept: [Organization](../access-governance/organization.mdx)
-
-## FHIR reference
-
-Care's device aligns with the FHIR **Device** resource, which represents a manufactured item used in delivering healthcare. Care extends it with location and encounter history so equipment can be traced across its working life.
+- Flow: [Create a device](../../flows/facility/device/create-device.mdx)
+- Flow: [View devices and a device's details](../../flows/facility/device/view-devices.mdx)
+- Flow: [Edit a device](../../flows/facility/device/edit-device.mdx)
+- Flow: [Link a device to a location and a department](../../flows/facility/device/link-device-location-department.mdx)
+- Flow: [Record a device's service history](../../flows/facility/device/device-service-history.mdx)
+- Flow: [Delete a device](../../flows/facility/device/delete-device.mdx)
+- Concept: [Department](../../concepts/facility/department.mdx)
+- Concept: [Locations](../../concepts/facility/location.mdx)

--- a/versioned_docs/version-3.1/concepts/facility/healthcare-service.mdx
+++ b/versioned_docs/version-3.1/concepts/facility/healthcare-service.mdx
@@ -4,53 +4,39 @@ sidebar_position: 5
 
 # Healthcare Service
 
-A **healthcare service** is a named offering that a facility provides — cardiology, a laboratory, radiology, a pharmacy, an outpatient clinic. It is the "what we offer" catalog entry: the thing patients book into, the thing schedules attach to, and the link between a clinical activity and the part of the facility accountable for it.
+## Definition
 
-## What it represents
+A **healthcare service** in Care is a service that a facility offers. A pharmacy counter, a lab, and a scheduling desk are healthcare services. Care's healthcare service is similar in structure to the FHIR [HealthcareService](https://build.fhir.org/healthcareservice.html) resource.
 
-In Care's FHIR-aligned model, a healthcare service maps to the **HealthcareService** resource. It captures:
+## Key Attributes
 
-- **Identity** — a display name and free-text details describing the offering
-- **Classification** — a coded service type and an internal type that tells the platform how the service behaves
-- **Placement** — the locations within the facility where the service is delivered
-- **Ownership** — the managing organization (a department or team) accountable for running it
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the healthcare service. This is required. |
+| Internal Type | The kind of service: Pharmacy, Lab, Scheduling, or Store. This is optional. |
+| Extra Details | More information about the service, in free text. You can leave this empty. |
+| Locations | The locations in the facility where the service is available. You must select at least one location. |
+| Managing Organization | The department of the facility that manages the service. This is optional. |
+| Icon | An icon that Care shows for the service in the services list and on the service details page. This is optional. |
 
-A healthcare service is a *description of an offering*, not an appointment and not a place. It says "this facility offers cardiology, run by the cardiology department, in these rooms" — but the act of seeing a patient is an [encounter](../clinical/encounter.mdx), and the room itself is a [location](../facility/location.mdx). The service is the stable bridge that ties offering, owner, and place together; patients flow through it, but it outlives any single visit.
+### Managing Organization
 
-## Classification
+The form shows this field in a section named Managing Organization. The picker lists the departments of the facility. Select one department, or leave the field empty. See [Department](../../concepts/facility/department.mdx).
 
-A service carries two labels, and they answer different questions.
-
-- **Service type** — a coded value drawn from a standard service-type terminology (such as the HL7 `service-type` code system). This is the label a person recognizes: "Cardiology", "General Practice", "Diagnostic Imaging". It answers *what kind of service is this?*
-- **Internal type** — one of `pharmacy`, `lab`, `scheduling`, or `store`. This answers *how should the platform treat this service?* It wires the service into the matching workflow: `pharmacy` into medication dispensing, `lab` into diagnostics, `scheduling` into appointment booking, `store` into supply handling.
-
-Read service type as the public-facing name and internal type as the behavioral switch that connects the service to the rest of Care.
-
-## How it connects
-
-A healthcare service is owned and placed, never free-floating:
-
-- It belongs to exactly one [facility](../facility/facility.mdx) — the place that offers it — set automatically from context, never chosen by hand.
-- It is owned by one [facility organization](../access-governance/facility-organization.mdx), the department or team accountable for it.
-- It is delivered across one or more [locations](../facility/location.mdx), so a single service can span several rooms or wards.
-
-Schedulable services are also what patients reserve time against, through [schedules](../scheduling/schedule.mdx) and [bookings](../scheduling/booking.mdx). The service stays put; the encounters and bookings move through it.
+Note: Care can also use a healthcare service as a resource for appointment scheduling. This document does not cover scheduling setup.
 
 ## Permissions
 
-Access to healthcare services is governed by two facility-scoped permissions.
-
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_healthcare_service` | Create, update, or delete a healthcare service on a facility | Facility Admin, Admin |
-| `can_read_healthcare_service` | View healthcare services offered at a facility | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-
-Roles are granted through a user's membership in an organization or facility, and permissions cascade down the organization tree — a role held at a parent organization applies to the facilities and services beneath it.
+| Permission | What it allows |
+| --- | --- |
+| Can Create Healthcare Service on Facility | Create, edit, or delete a healthcare service. Facility Admin and Admin hold this permission. Care checks this permission on the root department of the facility, not on a sub-department. |
+| Can Read Healthcare Service | View healthcare services. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist hold this permission. |
 
 ## Related
 
-- Reference: [Healthcare Service (technical)](../../references/facility/healthcare-service.mdx)
-- Concept: [Facility](../facility/facility.mdx)
-- Concept: [Facility Organization](../access-governance/facility-organization.mdx)
-- Concept: [Location](../facility/location.mdx)
-- Concept: [Schedule](../scheduling/schedule.mdx)
+- Flow: [Create a healthcare service](../../flows/facility/healthcare-service/create-healthcare-service.mdx)
+- Flow: [View healthcare services and a service's details](../../flows/facility/healthcare-service/view-healthcare-services.mdx)
+- Flow: [Edit a healthcare service](../../flows/facility/healthcare-service/edit-healthcare-service.mdx)
+- Flow: [Delete a healthcare service](../../flows/facility/healthcare-service/delete-healthcare-service.mdx)
+- Concept: [Locations](../../concepts/facility/location.mdx)
+- Concept: [Department](../../concepts/facility/department.mdx)

--- a/versioned_docs/version-3.1/concepts/facility/resource-request.mdx
+++ b/versioned_docs/version-3.1/concepts/facility/resource-request.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 7
+---
+
+# Resource Request
+
+## Definition
+
+A **resource request** in Care is a request that one facility sends to another facility. The request asks for a resource that a patient or a facility needs. A request can ask for clinical care and social support, comfort devices, medicines, or financial support.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Request Title | The short title of the request. This is required. |
+| Is this an Emergency? | Whether the request is urgent. Select Yes or No. |
+| Category | The kind of resource that you need. This is required. |
+| Reason of Request | Why you need the resource. This is required. |
+| Name of Contact Person at Facility | The name of the person to contact about this request. This is required. |
+| Contact Person Number | The phone number to contact about this request. This is required. |
+| Facility for Care Support | The facility that you ask for help. This is required. |
+| Status | The current state of the request. See Status below. |
+| Assigned to | The user at the Facility for Care Support who handles the request. This is optional. Care shows this field only when you update a request, not when you create one. |
+| Linked Patient | The patient that this request is for. |
+
+### Category
+
+Category records the kind of resource that you need. Select one of these values:
+
+- Clinical Care and Social Support
+- Comfort Devices
+- Medicines
+- Financial
+- Other
+
+### Status
+
+| Status | Description |
+| --- | --- |
+| Pending | The request waits for a response. |
+| Approved | The Facility for Care Support approved the request. |
+| Transportation to be arranged | Someone must arrange transport for this request. |
+| Transfer in progress | The transfer has started. |
+| Completed | The request is complete. |
+| Rejected | The Facility for Care Support rejected the request. |
+| Cancelled | The request is cancelled. |
+
+Note: Care does not enforce an order for these statuses. Any user who can update the request can set any status at any time. Care has no separate Approve, Reject, or Cancel actions. There is only one status choice.
+
+## Permissions
+
+Care does not have a dedicated set of permissions for resource requests. Anyone who belongs to a facility organization connected to the request can view, create, update, or delete that request. A connected user can also change the status of the request. Care connects a request to the facility that sent it and to the Facility for Care Support. Care does not separate who can create a request from who can approve one.
+
+## Related
+
+- Flow: [Create a resource request](../../flows/facility/resource-request/create-resource-request.mdx)
+- Flow: [View resource requests](../../flows/facility/resource-request/view-resource-requests.mdx)
+- Flow: [Update a resource request's status](../../flows/facility/resource-request/update-resource-request-status.mdx)
+- Flow: [Comment on a resource request](../../flows/facility/resource-request/comment-resource-request.mdx)
+- Flow: [Print a resource request letter](../../flows/facility/resource-request/print-resource-request-letter.mdx)
+- Concept: [Patient](../../concepts/clinical/patient)

--- a/versioned_docs/version-3.1/flows/facility/device/_category_.json
+++ b/versioned_docs/version-3.1/flows/facility/device/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Device",
+  "position": 4,
+  "key": "facility-device-flows"
+}

--- a/versioned_docs/version-3.1/flows/facility/device/create-device.mdx
+++ b/versioned_docs/version-3.1/flows/facility/device/create-device.mdx
@@ -1,0 +1,67 @@
+---
+sidebar_position: 1
+---
+
+# Create a device
+
+## Overview
+
+This flow describes how to register a new [device](../../../concepts/facility/device.mdx) in a facility in Care.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Devices on Facility | Lets you create a device. Staff, Admin, Facility Admin, and Pharmacist hold this permission. |
+
+## Steps
+
+### 1. Open the devices list
+
+Open the facility. Select **Settings**. Select **Devices**.
+
+### 2. Start a new device
+
+Select **Add Device**.
+
+Note: If your deployment adds device types, **Add Device** opens a list of types. Select a type, or select **Other** for a device with no type.
+
+### 3. Complete the form
+
+| Components | What it captures |
+| --- | --- |
+| Registered Name | The name Care uses to identify the device. This is required. |
+| User Friendly Name | A more familiar name for the device. This is optional. |
+| Identifier | An identifier for the device, for example an inventory tag. This is optional. |
+| Status | Whether the device is Active, Inactive, or Entered in Error. This is required, and it defaults to Active. |
+| Availability Status | Whether the device is Available, Lost, Damaged, or Destroyed. This is required, and it defaults to Available. |
+| Manufacturer | The maker of the device. This is optional. |
+| Manufacture Date | When the device was made. This is optional, and it cannot be a future date. |
+| Expiration Date | When the device expires. This is optional, and it must be after the manufacture date. |
+| Lot Number, Serial Number, Model Number, Part Number | The numbers that the maker prints on the device or its package. These are optional. |
+| Contact Points | Contact details for the device, for example a vendor support line. This is optional. Each contact detail has a type and a value. The type is Phone, Fax, SMS, Email, URL, Pager, or Other. Care rejects the same contact value more than once, even under a different type. |
+
+### 4. Save the device
+
+Select **Save**.
+
+## Expected Outcome
+
+- Care creates the device.
+- Care shows the message "Device registered successfully".
+
+## Related
+
+Concepts:
+
+- [Device](../../../concepts/facility/device.mdx)
+
+Flows:
+
+- [View devices and a device's details](./view-devices.mdx)
+- [Link a device to a location and a department](./link-device-location-department.mdx)

--- a/versioned_docs/version-3.1/flows/facility/device/delete-device.mdx
+++ b/versioned_docs/version-3.1/flows/facility/device/delete-device.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 6
+---
+
+# Delete a device
+
+## Overview
+
+This flow describes how to delete a [device](../../../concepts/facility/device.mdx) from a facility in Care.
+
+## Pre-requisites
+
+- The device is registered in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Devices on Facility | Lets you delete a device. Staff, Admin, Facility Admin, and Pharmacist hold this permission. |
+
+## Steps
+
+### 1. Open the device
+
+Open the facility. Select **Settings**. Select **Devices**. Select the device.
+
+### 2. Go to the Danger Zone
+
+Go to the **Danger Zone** section at the bottom of the page.
+
+### 3. Select Delete
+
+Select **Delete**. Care shows a confirmation dialog. The dialog warns you that you cannot undo this action.
+
+### 4. Confirm the deletion
+
+Select **Delete** in the dialog.
+
+## Expected Outcome
+
+- Care deletes the device.
+- Care returns you to the devices list.
+
+## Related
+
+Concepts:
+
+- [Device](../../../concepts/facility/device.mdx)
+
+Flows:
+
+- [Create a device](./create-device.mdx)
+- [Edit a device](./edit-device.mdx)

--- a/versioned_docs/version-3.1/flows/facility/device/device-service-history.mdx
+++ b/versioned_docs/version-3.1/flows/facility/device/device-service-history.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 5
+---
+
+# Record a device's service history
+
+## Overview
+
+This flow describes how to record and edit maintenance records for a [device](../../../concepts/facility/device.mdx) in Care.
+
+## Pre-requisites
+
+- The device is registered in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Devices on Facility | Lets you add or edit a service record. Staff, Admin, Facility Admin, and Pharmacist hold this permission. |
+
+## Steps
+
+### 1. Open the device
+
+Open the facility. Select **Settings**. Select **Devices**. Select the device.
+
+### 2. Find the Service History card
+
+The **Service History** card shows the maintenance records for the device. If the device has no records, the card shows "No service history available".
+
+### 3. Add a service record
+
+1. Select **Add Service Record**.
+2. Enter the **Service Date**.
+3. Enter the **Notes**.
+4. Select **Save**.
+
+Note: The service date and the notes are mandatory. The service date must be today or a past date.
+
+### 4. Edit a service record
+
+1. Select the edit icon on the record.
+2. Update the **Service Date** or the **Notes**.
+3. Select **Update**.
+
+## Expected Outcome
+
+- The **Service History** card shows the record that you added or changed.
+
+## Related
+
+Concepts:
+
+- [Device](../../../concepts/facility/device.mdx)
+
+Flows:
+
+- [View devices and a device's details](./view-devices.mdx)

--- a/versioned_docs/version-3.1/flows/facility/device/edit-device.mdx
+++ b/versioned_docs/version-3.1/flows/facility/device/edit-device.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+---
+
+# Edit a device
+
+## Overview
+
+This flow describes how to change the details of an existing [device](../../../concepts/facility/device.mdx) in Care.
+
+## Pre-requisites
+
+- The device is registered in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Devices on Facility | Lets you edit a device. Staff, Admin, Facility Admin, and Pharmacist hold this permission. |
+
+## Steps
+
+### 1. Open the device
+
+Open the facility. Select **Settings**. Select **Devices**. Select the device.
+
+### 2. Start the edit
+
+Select **Edit** on the **Device Information** card.
+
+### 3. Update the details
+
+Update the fields you want to change. Care uses the same form as when you create a device. For a description of each field, see [Create a device](./create-device.mdx).
+
+The same rules apply when you edit:
+
+- Registered Name, Status, and Availability Status stay mandatory.
+- The manufacture date cannot be a future date.
+- The expiration date must be after the manufacture date.
+- Care rejects the same contact value more than once.
+
+Note: You cannot change the location or the managing organization on this form. See [Link a device to a location and a department](./link-device-location-department.mdx).
+
+### 4. Save the changes
+
+Select **Save**.
+
+## Expected Outcome
+
+- Care saves the new details of the device.
+- Care shows the message "Device updated successfully".
+
+## Related
+
+Concepts:
+
+- [Device](../../../concepts/facility/device.mdx)
+
+Flows:
+
+- [Create a device](./create-device.mdx)
+- [Link a device to a location and a department](./link-device-location-department.mdx)
+- [Delete a device](./delete-device.mdx)

--- a/versioned_docs/version-3.1/flows/facility/device/link-device-location-department.mdx
+++ b/versioned_docs/version-3.1/flows/facility/device/link-device-location-department.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 4
+---
+
+# Link a device to a location and a department
+
+## Overview
+
+This flow describes how to link a [device](../../../concepts/facility/device.mdx) to a location and to a department in Care. It also describes how to change either one later.
+
+## Pre-requisites
+
+- The device is registered in the facility.
+- The location or department you want to link belongs to the same facility as the device.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Devices on Facility | Lets you link or change a device's location or department. Staff, Admin, Facility Admin, and Pharmacist hold this permission. |
+| Can Create/Update Facility Locations | Gives you write access to the specific location you link. Facility Admin, Admin, and Staff hold this permission. |
+| Can Manage Facility Organizations | Gives you write access to the specific department you link. Facility Admin and Administrator hold this permission. |
+
+## Steps
+
+### 1. Open the device
+
+Open the facility. Select **Settings**. Select **Devices**. Select the device.
+
+### 2. Link or change the device's location
+
+On the **Device Information** card, find the **Location** row.
+
+If no location is set, select **Associate**. If a location is already set, select **Change**.
+
+Search for the location. Select the location. Select **Associate**.
+
+Care shows the new location on the card. Care also adds the previous location to the device's **Location History**.
+
+Note: To remove the device from its current location without setting a new one, select **Disassociate**.
+
+### 3. Link or change the device's managing department
+
+On the **Device Information** card, find the **Managing Organization** row.
+
+If no department is set, select **Associate**. If a department is already set, select **Change**.
+
+Select the department. Select **Add Organization**.
+
+## Expected Outcome
+
+- The **Device Information** card shows the current location and the current managing department.
+- The **Location History** in the location sheet shows every location the device has been in.
+
+## Related
+
+Concepts:
+
+- [Device](../../../concepts/facility/device.mdx)
+- [Locations](../../../concepts/facility/location.mdx)
+- [Department](../../../concepts/facility/department.mdx)
+
+Flows:
+
+- [Create a device](./create-device.mdx)
+- [View devices and a device's details](./view-devices.mdx)
+- [Edit a device](./edit-device.mdx)

--- a/versioned_docs/version-3.1/flows/facility/device/view-devices.mdx
+++ b/versioned_docs/version-3.1/flows/facility/device/view-devices.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_position: 2
+---
+
+# View devices and a device's details
+
+## Overview
+
+This flow describes how to browse the [devices](../../../concepts/facility/device.mdx) of a facility. It also describes how to open one device to see its details.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can List Devices on Facility | Lets you view devices and their details. Staff, Admin, Doctor, Nurse, Facility Admin, and Pharmacist hold this permission. |
+
+## Steps
+
+### 1. Open the devices list
+
+1. Open the facility.
+2. Select **Settings**.
+3. Select **Devices**.
+
+Care shows the devices as cards.
+
+### 2. Search or filter the devices
+
+1. Enter a name in the search box to find a device.
+2. If your deployment adds device types, select **Filter by Type** to show the devices of one type. Select **All Types** to clear the filter.
+
+### 3. Open a device
+
+Select a device card. Care shows these sections:
+
+- **Device Information**
+- **Contact Information**, if the device has any contact details
+- **Service History**
+- **Danger Zone**
+
+## Expected Outcome
+
+- Care shows the devices of the facility.
+- Care shows the details of the device you select.
+
+## Related
+
+Concepts:
+
+- [Device](../../../concepts/facility/device.mdx)
+
+Flows:
+
+- [Create a device](./create-device.mdx)
+- [Edit a device](./edit-device.mdx)
+- [Link a device to a location and a department](./link-device-location-department.mdx)
+- [Record a device's service history](./device-service-history.mdx)
+- [Delete a device](./delete-device.mdx)

--- a/versioned_docs/version-3.1/flows/facility/healthcare-service/_category_.json
+++ b/versioned_docs/version-3.1/flows/facility/healthcare-service/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Healthcare Service",
+  "position": 5,
+  "key": "facility-healthcare-service-flows"
+}

--- a/versioned_docs/version-3.1/flows/facility/healthcare-service/create-healthcare-service.mdx
+++ b/versioned_docs/version-3.1/flows/facility/healthcare-service/create-healthcare-service.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 1
+---
+
+# Create a healthcare service
+
+## Overview
+
+This flow describes how to create a new [healthcare service](../../../concepts/facility/healthcare-service.mdx) in a facility in Care.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- The facility has at least one location. You must select a location for the service.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Healthcare Service on Facility | Lets you create a healthcare service. Facility Admin and Admin hold this permission on the root department of the facility. |
+
+Note: Care shows the Add Healthcare Service button to every user who opens the healthcare services list. If you do not hold the permission, Care refuses the request when you save.
+
+## Steps
+
+### 1. Open the healthcare services list
+
+Open the facility. Select Settings. Select Healthcare Services.
+
+### 2. Select Add Healthcare Service
+
+Select Add Healthcare Service. Care opens the Create Healthcare Service form.
+
+### 3. Complete the form
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the healthcare service. This is required. |
+| Internal Type | The kind of service. Select Pharmacy, Lab, Scheduling, or Store. This is optional. |
+| Extra Details | More information about the service, in free text. You can leave this empty. |
+| Locations | The locations in the facility where the service is available. Select at least one location. |
+| Managing Organization | The department of the facility that manages the service. This is optional. |
+| Icon | An icon that Care shows for the service. This is optional. |
+
+### 4. Save the healthcare service
+
+Select Create.
+
+## Expected Outcome
+
+- Care creates the healthcare service.
+- Care shows the message "Healthcare service created successfully".
+- Care returns you to the healthcare services list, where the new service appears.
+
+## Related
+
+Concepts:
+
+- [Healthcare Service](../../../concepts/facility/healthcare-service.mdx)
+
+Flows:
+
+- [View healthcare services and a service's details](./view-healthcare-services.mdx)
+- [Edit a healthcare service](./edit-healthcare-service.mdx)
+- [Delete a healthcare service](./delete-healthcare-service.mdx)

--- a/versioned_docs/version-3.1/flows/facility/healthcare-service/delete-healthcare-service.mdx
+++ b/versioned_docs/version-3.1/flows/facility/healthcare-service/delete-healthcare-service.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 4
+---
+
+# Delete a healthcare service
+
+## Overview
+
+This flow describes how to delete a [healthcare service](../../../concepts/facility/healthcare-service.mdx) from a facility in Care.
+
+## Pre-requisites
+
+- The healthcare service is set up in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Healthcare Service on Facility | Lets you delete a healthcare service. Facility Admin and Admin hold this permission on the root department of the facility. |
+
+Note: Care shows the Delete button only to users who hold this permission.
+
+## Steps
+
+### 1. Open the healthcare service
+
+Open the facility. Select Settings. Select Healthcare Services. Select the service.
+
+### 2. Start the deletion
+
+Select Delete.
+
+### 3. Confirm the deletion
+
+Care asks "Are you sure you want to delete this healthcare service?". Select Confirm.
+
+## Expected Outcome
+
+- Care deletes the healthcare service.
+- Care shows the message "Healthcare service deleted successfully".
+- Care returns you to the healthcare services list.
+
+## Related
+
+Concepts:
+
+- [Healthcare Service](../../../concepts/facility/healthcare-service.mdx)
+
+Flows:
+
+- [Create a healthcare service](./create-healthcare-service.mdx)
+- [View healthcare services and a service's details](./view-healthcare-services.mdx)
+- [Edit a healthcare service](./edit-healthcare-service.mdx)

--- a/versioned_docs/version-3.1/flows/facility/healthcare-service/edit-healthcare-service.mdx
+++ b/versioned_docs/version-3.1/flows/facility/healthcare-service/edit-healthcare-service.mdx
@@ -1,0 +1,60 @@
+---
+sidebar_position: 3
+---
+
+# Edit a healthcare service
+
+## Overview
+
+This flow describes how to change the details of an existing [healthcare service](../../../concepts/facility/healthcare-service.mdx) in Care.
+
+## Pre-requisites
+
+- The healthcare service is set up in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Healthcare Service on Facility | Lets you edit a healthcare service. Facility Admin and Admin hold this permission on the root department of the facility. |
+
+Note: Care shows the Edit button to every user who opens a healthcare service. If you do not hold the permission, Care refuses the request when you save.
+
+## Steps
+
+### 1. Open the healthcare service
+
+Open the facility. Select Settings. Select Healthcare Services. Select the service.
+
+### 2. Start the edit
+
+Select Edit. Care opens the Edit Healthcare Service form.
+
+### 3. Update the details
+
+Change the fields that you want to update. The form holds the same fields as the create form. For a description of each field, see [Create a healthcare service](./create-healthcare-service.mdx).
+
+Note: The Save button stays inactive until you change a field.
+
+### 4. Save the changes
+
+Select Save.
+
+## Expected Outcome
+
+- Care saves the new details of the healthcare service.
+- Care shows the message "Healthcare service updated successfully".
+- Care returns you to the details page of the service.
+
+## Related
+
+Concepts:
+
+- [Healthcare Service](../../../concepts/facility/healthcare-service.mdx)
+
+Flows:
+
+- [Create a healthcare service](./create-healthcare-service.mdx)
+- [View healthcare services and a service's details](./view-healthcare-services.mdx)
+- [Delete a healthcare service](./delete-healthcare-service.mdx)

--- a/versioned_docs/version-3.1/flows/facility/healthcare-service/view-healthcare-services.mdx
+++ b/versioned_docs/version-3.1/flows/facility/healthcare-service/view-healthcare-services.mdx
@@ -1,0 +1,55 @@
+---
+sidebar_position: 2
+---
+
+# View healthcare services and a service's details
+
+## Overview
+
+This flow describes how to browse the [healthcare services](../../../concepts/facility/healthcare-service.mdx) of a facility. It also describes how to open one service to see its details.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Healthcare Service | Lets you view healthcare services. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist hold this permission. |
+
+## Steps
+
+### 1. Open the healthcare services list
+
+Open the facility. Select Settings. Select Healthcare Services. Care shows the services as cards. Each card shows the icon, the name, and the extra details of the service. If the facility has many services, Care splits the list into pages.
+
+### 2. Search for a service
+
+Enter a part of the service name in the search box. Care filters the list as you type.
+
+### 3. Open a service
+
+Select a service card. Care shows the name of the service, its Extra Details, and its Locations. If a department manages the service, Care also shows it under Managing Organization.
+
+Note: Care does not show the Internal Type of the service on the details page. To check or change the Internal Type, open the service for editing.
+
+To go back to the list, select Back to List.
+
+## Expected Outcome
+
+- Care shows the healthcare services of the facility.
+- Care shows the details of the service you select.
+
+## Related
+
+Concepts:
+
+- [Healthcare Service](../../../concepts/facility/healthcare-service.mdx)
+
+Flows:
+
+- [Create a healthcare service](./create-healthcare-service.mdx)
+- [Edit a healthcare service](./edit-healthcare-service.mdx)
+- [Delete a healthcare service](./delete-healthcare-service.mdx)

--- a/versioned_docs/version-3.1/flows/facility/resource-request/_category_.json
+++ b/versioned_docs/version-3.1/flows/facility/resource-request/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Resource Request",
+  "position": 6,
+  "key": "facility-resource-request-flows"
+}

--- a/versioned_docs/version-3.1/flows/facility/resource-request/comment-resource-request.mdx
+++ b/versioned_docs/version-3.1/flows/facility/resource-request/comment-resource-request.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 4
+---
+
+# Comment on a resource request
+
+## Overview
+
+This flow describes how to add a comment to a [resource request](../../../concepts/facility/resource-request.mdx) in Care.
+
+## Pre-requisites
+
+- You created the resource request, or another facility sent the request to your facility.
+- You belong to a facility organization connected to the request.
+
+## Permissions
+
+Note: Care does not have a dedicated permission for this action. See [Resource Request](../../../concepts/facility/resource-request.mdx).
+
+## Steps
+
+### 1. Open the request
+
+Open the request. See [View resource requests](./view-resource-requests.mdx).
+
+### 2. Go to the Comments section
+
+Go to the Comments section of the request.
+
+### 3. Enter your comment
+
+Enter your comment in the text box.
+
+Note: Care keeps Post Your Comment inactive until you enter text. A comment that contains only spaces is not valid.
+
+### 4. Post the comment
+
+Select Post Your Comment.
+
+## Expected Outcome
+
+- Care adds your comment to the request.
+- Care shows a success message.
+
+## Related
+
+Concepts:
+
+- [Resource Request](../../../concepts/facility/resource-request.mdx)
+
+Flows:
+
+- [View resource requests](./view-resource-requests.mdx)
+- [Update a resource request's status](./update-resource-request-status.mdx)

--- a/versioned_docs/version-3.1/flows/facility/resource-request/create-resource-request.mdx
+++ b/versioned_docs/version-3.1/flows/facility/resource-request/create-resource-request.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+---
+
+# Create a resource request
+
+## Overview
+
+This flow describes how to create a new [resource request](../../../concepts/facility/resource-request.mdx) in Care. You start the flow from a patient's record.
+
+## Pre-requisites
+
+- You belong to a facility organization in Care.
+- The patient is registered in Care.
+- You open the patient from a facility.
+
+## Permissions
+
+Note: Care does not have a dedicated permission for this action. Anyone who belongs to a facility organization can create a resource request. See [Resource Request](../../../concepts/facility/resource-request.mdx).
+
+## Steps
+
+### 1. Open the resource request form
+
+Open the patient from your facility. Select the Requests tab. Select Create Request.
+
+Care opens the resource request form. Care links the new request to this patient. The form shows a Linked Patient note.
+
+### 2. Complete the form
+
+| Components | What it captures |
+| --- | --- |
+| Facility for Care Support | The facility that you ask for help. Required. |
+| Is this an Emergency? | Whether the request is urgent. Select Yes or No. |
+| Status | The current state of the request. Required. Care sets Pending as the first value. |
+| Category | The kind of resource that you need. Required. Choose Clinical Care and Social Support, Comfort Devices, Medicines, Financial, or Other. |
+| Request Title | The short title of the request. Required. |
+| Reason of Request | Why you need the resource. Required. |
+| Name of Contact Person at Facility | The name of the person to contact about this request. Required. Select Fill My Details to use your own name. |
+| Contact Person Number | The phone number to contact about this request. Required. |
+
+### 3. Submit the request
+
+Select Submit.
+
+## Expected Outcome
+
+- Care creates the resource request.
+- Care shows a success message.
+- Care opens the details of the request.
+
+## Related
+
+Concepts:
+
+- [Resource Request](../../../concepts/facility/resource-request.mdx)
+
+Flows:
+
+- [View resource requests](./view-resource-requests.mdx)
+- [Update a resource request's status](./update-resource-request-status.mdx)

--- a/versioned_docs/version-3.1/flows/facility/resource-request/print-resource-request-letter.mdx
+++ b/versioned_docs/version-3.1/flows/facility/resource-request/print-resource-request-letter.mdx
@@ -1,0 +1,53 @@
+---
+sidebar_position: 5
+---
+
+# Print a resource request letter
+
+## Overview
+
+This flow describes how to print a formal letter for a [resource request](../../../concepts/facility/resource-request.mdx) in Care.
+
+## Pre-requisites
+
+- You created the resource request, or another facility sent the request to your facility.
+- You belong to a facility organization connected to the request.
+
+## Permissions
+
+Note: Care does not have a dedicated permission for this action. See [Resource Request](../../../concepts/facility/resource-request.mdx).
+
+## Steps
+
+### 1. Open the request
+
+Open the request. See [View resource requests](./view-resource-requests.mdx).
+
+### 2. Select Request Letter
+
+Select Request Letter.
+
+### 3. Review the letter
+
+Care shows a printable letter. The letter shows the reference number of the request and the date. The letter shows the facility that sent the request, the title, the category, the reason, and the current status. The letter also shows who requested the resource.
+
+Note: If the status is Approved or Rejected, the letter shows a second signature line. This line names who approved or rejected the request, and when.
+
+### 4. Print the letter
+
+Select Print. You can also press P.
+
+## Expected Outcome
+
+- Care shows the printable letter for the request.
+- Your browser opens the print dialog.
+
+## Related
+
+Concepts:
+
+- [Resource Request](../../../concepts/facility/resource-request.mdx)
+
+Flows:
+
+- [View resource requests](./view-resource-requests.mdx)

--- a/versioned_docs/version-3.1/flows/facility/resource-request/update-resource-request-status.mdx
+++ b/versioned_docs/version-3.1/flows/facility/resource-request/update-resource-request-status.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 3
+---
+
+# Update a resource request's status
+
+## Overview
+
+This flow describes how to change the status of a [resource request](../../../concepts/facility/resource-request.mdx) in Care. The flow also describes how to assign the request to a user. Care uses one form for every status change. To approve, to reject, or to cancel a request, select the new status in that form.
+
+## Pre-requisites
+
+- You created the resource request, or another facility sent the request to your facility.
+- You belong to a facility organization connected to the request.
+
+## Permissions
+
+Note: Care does not have a dedicated permission for this action. Anyone who belongs to a facility organization connected to the request can change its status. See [Resource Request](../../../concepts/facility/resource-request.mdx).
+
+## Steps
+
+### 1. Open the request
+
+Open the request. See [View resource requests](./view-resource-requests.mdx).
+
+### 2. Select Update Status
+
+Care opens the same form that you use to create a request. Care fills in the current details.
+
+### 3. Choose the new status
+
+Select a new value in the Status field. The values are Pending, Approved, Transportation to be arranged, Transfer in progress, Completed, Rejected, and Cancelled.
+
+Note: Care does not restrict which status can follow which status. You can set any status at any time.
+
+### 4. Assign the request to a user
+
+This step is optional.
+
+Set the Facility for Care Support to the facility of the user. Select the user in the Assigned to field.
+
+### 5. Submit your changes
+
+Select Submit.
+
+## Expected Outcome
+
+- Care saves the new status.
+- Care saves the assigned user, if you set one.
+- The details of the request and the list of requests show the new status.
+
+## Related
+
+Concepts:
+
+- [Resource Request](../../../concepts/facility/resource-request.mdx)
+
+Flows:
+
+- [View resource requests](./view-resource-requests.mdx)
+- [Comment on a resource request](./comment-resource-request.mdx)

--- a/versioned_docs/version-3.1/flows/facility/resource-request/view-resource-requests.mdx
+++ b/versioned_docs/version-3.1/flows/facility/resource-request/view-resource-requests.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 2
+---
+
+# View resource requests
+
+## Overview
+
+This flow describes how to browse [resource requests](../../../concepts/facility/resource-request.mdx) from a facility or from a patient's record.
+
+## Pre-requisites
+
+- You belong to a facility organization connected to the requests you want to view.
+
+## Permissions
+
+Note: Care does not have a dedicated permission for this action. See [Resource Request](../../../concepts/facility/resource-request.mdx).
+
+## Steps
+
+### 1. View the resource requests of a facility
+
+Open the facility. Select Resource. Care shows the requests as cards. Each card shows the title, the reason, and the category. Each card also shows the facility that sent the request and the facility that receives it. Care adds an Emergency badge if the request is urgent.
+
+Select Outgoing or Incoming to switch between the two views. Outgoing shows the requests that your facility sent. Incoming shows the requests that other facilities sent to your facility.
+
+Select Active or Completed to choose a group of statuses. Active contains Pending, Approved, Transportation to be arranged, and Transfer in progress. Completed contains Completed, Rejected, and Cancelled.
+
+Select one status in the group. Care shows the requests that have that status.
+
+Search for a request by title.
+
+### 2. View the resource requests of a patient
+
+Open the patient. Select the Requests tab. Care shows a table of the requests of the patient. The table shows the resource type, the title, and the status. The table also shows the dates when Care created and last changed the request.
+
+### 3. Open a request
+
+Select View Details on a card. In the table of the patient, select View.
+
+Care shows the full request. The request shows the status, the category, the contact details, and the reason. The request also shows the linked patient, if there is one. The request shows the current facility, the facility assigned, and who created and last changed the request.
+
+## Expected Outcome
+
+- You see the resource requests that match your view and your filters.
+- You see the full details of a request you open.
+
+## Related
+
+Concepts:
+
+- [Resource Request](../../../concepts/facility/resource-request.mdx)
+
+Flows:
+
+- [Create a resource request](./create-resource-request.mdx)
+- [Update a resource request's status](./update-resource-request-status.mdx)
+- [Comment on a resource request](./comment-resource-request.mdx)
+- [Print a resource request letter](./print-resource-request-letter.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -95,6 +95,42 @@
                 "flows/facility/location/delete-location",
                 "flows/facility/location/manage-location-organizations"
               ]
+            },
+            {
+              "type": "category",
+              "label": "Device",
+              "key": "facility-device-flows",
+              "items": [
+                "flows/facility/device/create-device",
+                "flows/facility/device/view-devices",
+                "flows/facility/device/edit-device",
+                "flows/facility/device/link-device-location-department",
+                "flows/facility/device/device-service-history",
+                "flows/facility/device/delete-device"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Healthcare Service",
+              "key": "facility-healthcare-service-flows",
+              "items": [
+                "flows/facility/healthcare-service/create-healthcare-service",
+                "flows/facility/healthcare-service/view-healthcare-services",
+                "flows/facility/healthcare-service/edit-healthcare-service",
+                "flows/facility/healthcare-service/delete-healthcare-service"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Resource Request",
+              "key": "facility-resource-request-flows",
+              "items": [
+                "flows/facility/resource-request/create-resource-request",
+                "flows/facility/resource-request/view-resource-requests",
+                "flows/facility/resource-request/update-resource-request-status",
+                "flows/facility/resource-request/comment-resource-request",
+                "flows/facility/resource-request/print-resource-request-letter"
+              ]
             }
           ]
         },


### PR DESCRIPTION
## What

Publishes the **Device**, **Healthcare Service** and **Resource Request** documentation from `care_docs` into the docs site (version 3.1).

### Device

- Replaces `concepts/facility/device.mdx` with the authored version
- Six flows under `flows/facility/device/`: create, view, edit, link to a location and department, record service history, delete

### Healthcare Service

- Replaces `concepts/facility/healthcare-service.mdx` with the authored version
- Four flows under `flows/facility/healthcare-service/`: create, view, edit, delete

### Resource Request

- New concept at `concepts/facility/resource-request.mdx`
- Five flows under `flows/facility/resource-request/`: create, view, update status, comment, print letter

All three sit as module categories under `Flows > Facility`.

## Stacked on #78

This branches off `docs/facility-department-location` (#78), because the Device, Healthcare Service and Resource Request docs all link to the Department concept that #78 introduces. GitHub retargets this PR to `main` once #78 merges.

## Notes for reviewers

- Device and Healthcare Service concepts are **replaced**, not extended.
- Resource Request is new as a concept. A technical reference already exists at `references/platform/resource-request.mdx`, under the platform domain rather than facility; worth deciding whether the two should sit in the same domain.
- Flow titles were changed from "How to Create a Device" to "Create a device" to match the other modules.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
