### PR TITLE
Add Scheduling docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/scheduling/exception.mdx
+++ b/versioned_docs/version-3.1/concepts/scheduling/exception.mdx
@@ -1,0 +1,45 @@
+---
+sidebar_position: 4
+---
+
+# Schedule Exception
+
+## Definition
+
+A **schedule exception** in Care records a period when a resource is not available, even though a schedule makes it available. The resource is a practitioner, a location, or a healthcare service.
+
+An exception overrides the regular schedule. Care does not offer slots for booking during the period of the exception.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Reason | The reason for the unavailability, for example leave or a holiday. This is required. |
+| Valid From | The first date of the unavailability. This is required. |
+| Valid Till | The last date of the unavailability. This is required. |
+| Full day unavailable | Whether the resource is unavailable for the whole day. |
+| Start time | The time that the unavailability starts on each day. This is required when the resource is not unavailable for the full day. |
+| End time | The time that the unavailability ends on each day. This is required when the resource is not unavailable for the full day. |
+| Resource | The practitioner, location, or healthcare service that the exception belongs to. |
+
+An exception applies on every day in the period from Valid From to Valid Till. For a part-day exception, the same start time and end time apply on each of those days.
+
+### Validation rules
+
+- The Valid From date must not be in the past. Care shows the message "Schedule exception cannot be created for the past".
+- The Valid Till date must be the same as, or later than, the Valid From date.
+- The start time must be earlier than the end time.
+
+## Permissions
+
+| Permission | What it allows |
+| --- | --- |
+| Can Create on Schedule | Create and remove schedule exceptions. |
+| Can list schedule on Object | See the exceptions of a resource. |
+
+## Related
+
+- Concept: [Schedule & Availability](../../concepts/scheduling/schedule.mdx)
+- Flow: [Create a schedule exception](../../flows/scheduling/exception/create-schedule-exception.mdx)
+- Flow: [View schedule exceptions](../../flows/scheduling/exception/view-schedule-exceptions.mdx)
+- Flow: [Remove a schedule exception](../../flows/scheduling/exception/remove-schedule-exception.mdx)

--- a/versioned_docs/version-3.1/concepts/scheduling/schedule.mdx
+++ b/versioned_docs/version-3.1/concepts/scheduling/schedule.mdx
@@ -4,65 +4,80 @@ sidebar_position: 1
 
 # Schedule & Availability
 
-A **schedule** is a named, date-bounded block of time during which a bookable resource — a practitioner, a location, or a healthcare service — accepts appointments. It is the supply side of scheduling: a schedule declares when care can be booked, so the rest of the platform knows which slots to offer patients.
+## Definition
 
-## What it represents
+A **[schedule](https://build.fhir.org/schedule.html)** in Care records when a resource can be booked at a facility. The resource is a practitioner, a location, or a healthcare service. Each schedule holds one or more availability sessions. A session states the days of the week, the start time and the end time when the resource is available.
 
-In Care's FHIR-aligned model, a schedule maps to the **Schedule** resource, and the way it produces bookable times mirrors how FHIR derives **Slot**s from a schedule's planning horizon. A schedule captures:
+Care creates bookable slots from the schedule. Staff and patients book appointments against these slots.
 
-- **The resource** — who or what is being booked: a practitioner, a physical location, or a named healthcare service
-- **The effective window** — the dates between which this schedule applies, for example a doctor's roster for one quarter
-- **Availabilities** — one or more recurring time blocks (a morning OPD, an afternoon clinic) that say which days and hours are open and how that time divides into slots
-- **Exceptions** — specific dates and times when the resource is unavailable, such as leave or a public holiday
+## Key Attributes
 
-A schedule is not a list of appointments. It is the rule that *generates* bookable slots; the actual reservations live in [bookings](../scheduling/booking.mdx) and, where queues are used, in [tokens](../scheduling/token.mdx). Slots are never stored as rows — they are computed on demand from a schedule's availabilities with exceptions subtracted, so the schedule is always the single source of truth for what is bookable. Editing a schedule changes what *can* be booked going forward; it does not touch appointments that already exist.
+| Components | What it captures |
+| --- | --- |
+| Template Name | The name of the schedule template. This is required. |
+| Valid From | The first date that the schedule applies. This is required. |
+| Valid Till | The last date that the schedule applies. This is required. |
+| Resource | The practitioner, location, or healthcare service that the schedule belongs to. |
+| Availability sessions | One or more sessions. Each session holds a session title, a slot type, the days of the week, a start time and an end time. |
+| Public | Whether patients can see the schedule and book against it. A private schedule shows the message "This schedule is private". |
 
-## How a schedule is built up
+### Resource types
 
-Three pieces work together. The schedule is the container; availabilities and exceptions shape the slots it offers.
+A schedule belongs to one of these resource types:
 
-- **Schedule** — the named, dated block attached to one resource. Holds the effective window and any billing charge that applies to bookings made against it.
-- **Availability** — a recurring time block inside a schedule. It sets the slot type, how long each slot is, how many people each slot can hold, and which weekdays and hours it repeats on. A schedule can carry several, for example a morning and an afternoon block.
-- **Availability exception** — a one-off date range that blocks the resource regardless of its schedules. Used for leave, holidays, and unplanned closures.
+| Resource type | What it schedules |
+| --- | --- |
+| Practitioner | A user, for example a doctor or a nurse. |
+| Location | A place inside the facility, for example a consultation room. |
+| Healthcare Service | A service that the facility offers. |
 
-## Availability types
+A facility holds only one schedulable resource for each practitioner, each location, and each healthcare service.
 
-Each availability block has a **slot type** that decides how its time behaves:
+### Availability sessions
 
-```text
-appointment → open → closed
-```
+Each session in a schedule holds these values:
 
-- **appointment** — time-precise booking. The block is divided into fixed-length slots (for example, 15-minute slots), each holding a set number of people. Use this when patients book a specific time.
-- **open** — a block with no fixed slot size, suited to walk-in or queue-style flows where order matters more than an exact minute. Often paired with token generation.
-- **closed** — a block that is explicitly not bookable, used to carve a gap out of an otherwise open period.
+| Component | What it captures |
+| --- | --- |
+| Session Title | The name of the session, for example "IP Rounds". This is required. |
+| Slot type | Appointment Slot, Open, or Closed. This is required. |
+| Days of the week | The days that the session repeats. You select at least one day. |
+| Start time and end time | The time range of the session on each selected day. The start time must be earlier than the end time. |
+| Slot size in minutes | The length of one slot. This is required for an appointment slot. |
+| Tokens per slot | The number of patients that Care books into one slot. This is required for an appointment slot. |
+| Reason | Free text that explains the session. This is optional. |
 
-An appointment or open block can also issue a **token** for each booking, feeding the queue and token-display workflows that high-volume, walk-in clinics depend on.
+### Slot types
 
-## How it connects
+| Slot type | What it means |
+| --- | --- |
+| Appointment Slot | Care divides the session into slots of a fixed size. Patients book a specific slot. |
+| Open | The resource is available for the whole session, and Care does not divide the session into slots. |
+| Closed | The resource is not available for booking during the session. |
 
-A schedule sits at the center of the booking flow and links outward to several other primitives:
+### Validation rules
 
-- **Resource** — every schedule attaches to exactly one practitioner ([user](../access-governance/user.mdx)), [location](../facility/location.mdx), or [healthcare service](../facility/healthcare-service.mdx) within a [facility](../facility/facility.mdx).
-- **Bookings** — patients reserve generated slots, creating [bookings](../scheduling/booking.mdx) against the schedule.
-- **Tokens** — in queue-based clinics, a booking can also issue a [token](../scheduling/token.mdx) for the waiting line.
-- **Billing** — a schedule can carry a charge that applies to its bookings, with an optional reduced charge for follow-up visits within a configured window, drawn from a [charge item definition](../definitions/charge-item-definition.mdx).
+- The Valid From date must not be in the past.
+- The Valid From date must not be later than the Valid Till date.
+- The start time of a session must be earlier than its end time.
+- Sessions in a schedule must not overlap.
+- For an appointment slot, the length of the session must be a multiple of the slot size in minutes.
+- For an appointment slot, the number of slots in one session must not be more than the limit that your deployment sets.
 
 ## Permissions
 
-Access to schedules and the bookings made against them is governed by the facility-level permissions below.
+| Permission | What it allows |
+| --- | --- |
+| Can Create on Schedule | Create and change schedules and their sessions. |
+| Can list schedule on Object | See the schedules of a resource. |
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_schedule` | Create, update, and delete schedules and their availabilities for a resource | Admin, Staff, Facility Admin, Doctor, Nurse |
-| `can_list_schedule` | View the schedules and availabilities defined for a resource | Admin, Staff, Facility Admin, Doctor, Nurse, Administrator |
-| `can_set_charge_item_definition` | Attach a billing charge item definition (and revisit settings) to a schedule | Facility Admin, Admin |
+## Configuration
 
-Roles are granted through a user's facility and organization memberships, and permissions cascade down the organization tree — a role held on a parent organization applies to the facilities and resources beneath it.
+The maximum number of slots in one availability session depends on your deployment's configuration.
 
 ## Related
 
-- Reference: [Schedule & Availability (technical)](../../references/scheduling/schedule.mdx)
-- Concept: [Booking](../scheduling/booking.mdx)
-- Concept: [Token](../scheduling/token.mdx)
-- Concept: [Healthcare service](../facility/healthcare-service.mdx)
+- Flow: [Create a schedule template](../../flows/scheduling/schedule/create-schedule-template.mdx)
+- Flow: [View schedule templates](../../flows/scheduling/schedule/view-schedule-templates.mdx)
+- Flow: [Edit a schedule template](../../flows/scheduling/schedule/edit-schedule-template.mdx)
+- Flow: [Delete a schedule template](../../flows/scheduling/schedule/delete-schedule-template.mdx)

--- a/versioned_docs/version-3.1/concepts/scheduling/token.mdx
+++ b/versioned_docs/version-3.1/concepts/scheduling/token.mdx
@@ -4,59 +4,60 @@ sidebar_position: 3
 
 # Token
 
-A **token** is a numbered place in a queue — the digital version of pulling a ticket and waiting for your number to be called. It is how Care orders walk-in and queue-based flow: the patient sees where they stand, and staff see who to serve next.
+## Definition
 
-## What it represents
+A **token** in Care is a numbered place in a queue. Care gives a token to a patient so that staff call the patient in order.
 
-A token is not an appointment. A [booking](../scheduling/booking.mdx) reserves a specific slot ahead of time; a token simply orders the people who show up. The two can connect — a booking can issue a token when the patient arrives — but a token can also stand alone for pure walk-in flow.
+A token belongs to one token queue. The queue holds the tokens for one resource on one date. The resource is a practitioner, a location, or a healthcare service.
 
-Unlike most things in Care, a token doesn't map to a single FHIR resource. It's a queue-management primitive layered on top of scheduling: a number, the queue it belongs to, the category it counts within, its current state, and the patient holding it. Everything else about how tokens behave follows from how those pieces nest together.
+## Key Attributes
 
-## How it connects
+| Components | What it captures |
+| --- | --- |
+| Token Number | The number of the token in its queue. |
+| Patient | The patient that holds the token. |
+| Token Queue | The queue that the token belongs to. |
+| Token Category | The category of the token. This is required. |
+| Sub Queue | The service point that serves the token. This is optional. |
+| Status | The state of the token. |
+| Note | Free text about the token. This is optional. |
+| Booking | The appointment that the token belongs to, when staff generate the token from an appointment. |
 
-Tokens are assembled from a few cooperating pieces, and understanding how they nest is most of the concept:
+### Status values
 
-- **Queue** — a list of tokens for one schedulable resource (a doctor, a location, or a healthcare service) on one date. The first queue created for a resource on a date becomes the *primary* queue; new tokens flow into it by default.
-- **Sub-queue** — an optional split of one queue across several physical points. A vaccination clinic with three rooms runs one queue but routes patients to three sub-queues, each calling its own current token.
-- **Category** — a reusable label, with a short code, that separates streams within a queue, so a priority line and a general line each keep their own running count.
-- **Token** — the numbered ticket itself, issued to a patient inside a queue.
+| Status | What it means |
+| --- | --- |
+| Created | Care created the token, and the patient waits. |
+| In Progress | Staff are serving the patient. |
+| Fulfilled | Staff finished serving the patient. |
+| Unfulfilled | Staff did not serve the patient. |
+| Cancelled | Staff cancelled the token. |
+| Entered in Error | Staff recorded the token by mistake. |
 
-Because numbers are counted *per category within a queue*, two patients can both hold number 1 if they sit in different categories. The number orders a stream, not the whole queue.
+### Token queues
 
-## Lifecycle
+A token queue holds the tokens for one resource on one date. A queue has a name, and one queue for a resource is the primary queue. Care creates some queues automatically.
 
-A token moves through a small set of states as the patient is served:
+### Sub queues
 
-```text
-CREATED → IN_PROGRESS → FULFILLED
-            ↘ CANCELLED / ENTERED_IN_ERROR
-```
+A sub queue is a service point inside a queue. Use sub queues when more than one place serves the same queue, for example more than one room for vaccination. A sub queue is active or inactive, and it records the token that it serves now.
 
-- **CREATED** — issued and waiting in the queue (the default state)
-- **IN_PROGRESS** — now being served; set when the token becomes a sub-queue's current token
-- **FULFILLED** — service complete
-- **UNFULFILLED** — closed out without being served
-- **CANCELLED** — withdrawn before service
-- **ENTERED_IN_ERROR** — set automatically when a token is deleted, so the record closes without erasing history
+### Token categories
 
-Staff never pick the next token by hand. Care advances the queue for them — taking the oldest waiting token, marking it in progress, and pointing the sub-queue at it.
+A token category groups tokens, for example by the kind of visit. Each category has a name and a shorthand. An administrator sets one category as the default for the facility.
 
 ## Permissions
 
-Access to tokens is granted at the facility level — the same facility the queue belongs to.
-
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_token` | Issue, update, and delete tokens, and manage their queues and sub-queues for a schedulable resource | Admin, Staff, Facility Admin, Doctor, Nurse, Administrator |
-| `can_list_token` | View tokens, queues, and sub-queues for a schedulable resource | Admin, Staff, Facility Admin, Doctor, Nurse, Administrator |
-| `can_write_token_category` | Create, update, and set the default token category for a facility | Admin, Staff, Facility Admin |
-| `can_list_token_category` | View the token categories available in a facility | Admin, Staff, Facility Admin, Doctor, Nurse, Administrator |
-
-Roles come from a user's facility and organization memberships, and permissions cascade down the organization tree — so access granted higher up applies to the facilities beneath it.
+| Permission | What it allows |
+| --- | --- |
+| Can Create on Token | Create tokens and change them. |
+| Can list token on Object | See tokens and queues. |
+| Can Create on Token Category | Create and change token categories. |
+| Can list token category on Facility | See the token categories of the facility. |
 
 ## Related
 
-- Reference: [Token (technical)](../../references/scheduling/token.mdx)
-- Concept: [Schedule](../scheduling/schedule.mdx)
-- Concept: [Booking](../scheduling/booking.mdx)
-- Concept: [Patient](../clinical/patient)
+- Flow: [Create a token category](../../flows/scheduling/token/create-token-category.mdx)
+- Flow: [Create a token](../../flows/scheduling/token/create-token.mdx)
+- Flow: [Manage a token queue](../../flows/scheduling/token/manage-token-queue.mdx)
+- Flow: [Cancel a token](../../flows/scheduling/token/cancel-token.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/_category_.json
+++ b/versioned_docs/version-3.1/flows/scheduling/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Scheduling",
+  "position": 4,
+  "key": "scheduling-flows"
+}

--- a/versioned_docs/version-3.1/flows/scheduling/exception/_category_.json
+++ b/versioned_docs/version-3.1/flows/scheduling/exception/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Schedule Exception",
+  "position": 2,
+  "key": "scheduling-exception-flows"
+}

--- a/versioned_docs/version-3.1/flows/scheduling/exception/create-schedule-exception.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/exception/create-schedule-exception.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 1
+---
+
+# Create a schedule exception
+
+## Overview
+
+This flow describes how to record a period when a resource is not available in Care. The exception overrides the regular schedule, and Care does not offer slots during that period. See [Schedule Exception](../../../concepts/scheduling/exception.mdx).
+
+## Pre-requisites
+
+- The resource is available in the facility.
+- You can open the schedule of the resource.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Schedule | Lets you create a schedule exception. |
+| Can list schedule on Object | Lets you see the schedules of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource.
+
+### 2. Open the exceptions panel
+
+Select **Add Exception**. Care opens the **Add Schedule Exceptions** panel. The panel shows the text "Configure absences by adding unavailability beyond the regular schedule."
+
+### 3. Enter the reason
+
+Enter the **Reason** for the unavailability, for example leave or a holiday.
+
+### 4. Set the period
+
+Enter **Valid From** and **Valid Till**.
+
+The Valid From date must not be in the past. The Valid Till date must be the same as, or later than, the Valid From date.
+
+### 5. Set the times
+
+To make the resource unavailable for the whole day, select **Full day unavailable**.
+
+For a part of the day, leave that option clear and enter the start time and the end time. The start time must be earlier than the end time.
+
+### 6. Confirm the unavailability
+
+Select **Confirm Unavailability**. Care shows a message that the exception is created.
+
+## Expected Outcome
+
+- The exception appears in the list of schedule exceptions for the resource.
+- Care does not offer slots for booking during the period of the exception.
+
+## Related
+
+Concepts:
+
+- [Schedule Exception](../../../concepts/scheduling/exception.mdx)
+- [Schedule & Availability](../../../concepts/scheduling/schedule.mdx)
+
+Flows:
+
+- [View schedule exceptions](./view-schedule-exceptions.mdx)
+- [Remove a schedule exception](./remove-schedule-exception.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/exception/remove-schedule-exception.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/exception/remove-schedule-exception.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 3
+---
+
+# Remove a schedule exception
+
+## Overview
+
+This flow describes how to remove a period of unavailability from a resource in Care. Use it when the resource becomes available again. See [Schedule Exception](../../../concepts/scheduling/exception.mdx).
+
+## Pre-requisites
+
+- The schedule exception is created in Care.
+- You can open the schedule of the resource.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Schedule | Lets you remove a schedule exception. |
+| Can list schedule on Object | Lets you see the exceptions of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource. See [View schedule exceptions](./view-schedule-exceptions.mdx).
+
+### 2. Start the removal
+
+Find the exception that you want to remove. Select **Remove** on that exception.
+
+### 3. Confirm the removal
+
+Care asks "Are you sure?" and shows a warning. Select **Delete** to confirm.
+
+Care shows a message that the exception is deleted.
+
+## Expected Outcome
+
+- The exception no longer appears in the list of schedule exceptions.
+- Care offers slots again for the period, if a schedule covers it.
+
+## Related
+
+Concepts:
+
+- [Schedule Exception](../../../concepts/scheduling/exception.mdx)
+
+Flows:
+
+- [Create a schedule exception](./create-schedule-exception.mdx)
+- [View schedule exceptions](./view-schedule-exceptions.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/exception/view-schedule-exceptions.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/exception/view-schedule-exceptions.mdx
@@ -1,0 +1,49 @@
+---
+sidebar_position: 2
+---
+
+# View schedule exceptions
+
+## Overview
+
+This flow describes how to see the periods when a resource is not available in Care. See [Schedule Exception](../../../concepts/scheduling/exception.mdx).
+
+## Pre-requisites
+
+- The resource is available in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can list schedule on Object | Lets you see the exceptions of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource.
+
+### 2. Read the list of exceptions
+
+The page lists the schedule exceptions of the resource. Each exception shows its reason, its dates and its times.
+
+An exception for the whole day shows the date. An exception for a part of the day shows the start time and the end time.
+
+If the resource has no exception, the page shows the message "No scheduled exceptions found."
+
+## Expected Outcome
+
+- You see the periods when the resource is not available.
+
+## Related
+
+Concepts:
+
+- [Schedule Exception](../../../concepts/scheduling/exception.mdx)
+
+Flows:
+
+- [Create a schedule exception](./create-schedule-exception.mdx)
+- [Remove a schedule exception](./remove-schedule-exception.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/schedule/_category_.json
+++ b/versioned_docs/version-3.1/flows/scheduling/schedule/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Schedule & Availability",
+  "position": 1,
+  "key": "scheduling-schedule-flows"
+}

--- a/versioned_docs/version-3.1/flows/scheduling/schedule/create-schedule-template.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/schedule/create-schedule-template.mdx
@@ -1,0 +1,94 @@
+---
+sidebar_position: 1
+---
+
+# Create a schedule template
+
+## Overview
+
+This flow describes how to create a schedule template for a resource in Care. The template states when the resource is available, and Care creates bookable slots from it. See [Schedule & Availability](../../../concepts/scheduling/schedule.mdx).
+
+## Pre-requisites
+
+- The facility is created in Care.
+- The resource is available in the facility. The resource is a practitioner, a location, or a healthcare service.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Schedule | Lets you create a schedule template. |
+| Can list schedule on Object | Lets you see the schedules of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource that you want to schedule.
+
+### 2. Start a new template
+
+Select the option to add a schedule template. Care opens the **Schedule Template** panel.
+
+### 3. Name the template
+
+Enter the **Template Name**. The placeholder shows an example, "Regular OP Day".
+
+### 4. Set the validity period
+
+Enter **Valid From** and **Valid Till**.
+
+The Valid From date must not be in the past. The Valid From date must not be later than the Valid Till date.
+
+### 5. Select the days of the week
+
+Select the days that the template applies to. You select at least one day.
+
+### 6. Add a session
+
+Complete these fields for the session:
+
+| Field | What to enter |
+| --- | --- |
+| Session Title | The name of the session, for example "IP Rounds". |
+| Slot type | Appointment Slot, Open, or Closed. |
+| Start time | The time that the session starts. |
+| End time | The time that the session ends. |
+| Reason | Free text that explains the session. This is optional. |
+
+For an appointment slot, also complete these fields:
+
+| Field | What to enter |
+| --- | --- |
+| Slot size in minutes | The length of one slot. |
+| Tokens per slot | The number of patients that Care books into one slot. |
+
+The start time must be earlier than the end time. For an appointment slot, the length of the session must be a multiple of the slot size in minutes.
+
+To add more sessions, select **Add another session**. Sessions must not overlap.
+
+### 7. Set the visibility
+
+Set whether the schedule is public. Patients can see a public schedule and book against it. A private schedule shows the message "This schedule is private".
+
+### 8. Save the template
+
+Save the template. Care shows the message "Schedule template created successfully".
+
+## Expected Outcome
+
+- The template appears in the list of schedule templates for the resource.
+- Care creates bookable slots from the sessions in the template.
+
+## Related
+
+Concepts:
+
+- [Schedule & Availability](../../../concepts/scheduling/schedule.mdx)
+
+Flows:
+
+- [View schedule templates](./view-schedule-templates.mdx)
+- [Edit a schedule template](./edit-schedule-template.mdx)
+- [Delete a schedule template](./delete-schedule-template.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/schedule/delete-schedule-template.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/schedule/delete-schedule-template.mdx
@@ -1,0 +1,53 @@
+---
+sidebar_position: 4
+---
+
+# Delete a schedule template
+
+## Overview
+
+This flow describes how to remove a schedule template from a resource in Care. Use it when the template is no longer correct. See [Schedule & Availability](../../../concepts/scheduling/schedule.mdx).
+
+## Pre-requisites
+
+- The schedule template is created in Care.
+- You can open the schedule of the resource.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Schedule | Lets you delete a schedule template. |
+| Can list schedule on Object | Lets you see the schedules of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource. See [View schedule templates](./view-schedule-templates.mdx).
+
+### 2. Start the deletion
+
+Find the template that you want to remove. Select the delete action on that template.
+
+### 3. Confirm the deletion
+
+Care asks you to confirm. Read the warning, then confirm.
+
+## Expected Outcome
+
+- The template no longer appears in the list of schedule templates.
+- Care no longer creates slots from the sessions in that template.
+
+## Related
+
+Concepts:
+
+- [Schedule & Availability](../../../concepts/scheduling/schedule.mdx)
+
+Flows:
+
+- [Create a schedule template](./create-schedule-template.mdx)
+- [View schedule templates](./view-schedule-templates.mdx)
+- [Edit a schedule template](./edit-schedule-template.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/schedule/edit-schedule-template.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/schedule/edit-schedule-template.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 3
+---
+
+# Edit a schedule template
+
+## Overview
+
+This flow describes how to change a schedule template in Care. Use it when the availability of a resource changes. See [Schedule & Availability](../../../concepts/scheduling/schedule.mdx).
+
+## Pre-requisites
+
+- The schedule template is created in Care.
+- You can open the schedule of the resource.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Schedule | Lets you change a schedule template. |
+| Can list schedule on Object | Lets you see the schedules of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource. See [View schedule templates](./view-schedule-templates.mdx).
+
+### 2. Open the template
+
+Find the template that you want to change. Select the edit action on that template. Care opens the **Edit Schedule Template** panel with the current values.
+
+### 3. Change the details
+
+Change the values that you want. The same rules apply as at creation:
+
+- The Valid From date must not be later than the Valid Till date.
+- The start time of a session must be earlier than its end time.
+- Sessions must not overlap.
+- For an appointment slot, the length of the session must be a multiple of the slot size in minutes.
+
+### 4. Save the changes
+
+Save the template. Care shows the message "Schedule template updated successfully".
+
+## Expected Outcome
+
+- The template shows the new values.
+- Care creates bookable slots from the changed sessions.
+
+## Related
+
+Concepts:
+
+- [Schedule & Availability](../../../concepts/scheduling/schedule.mdx)
+
+Flows:
+
+- [Create a schedule template](./create-schedule-template.mdx)
+- [View schedule templates](./view-schedule-templates.mdx)
+- [Delete a schedule template](./delete-schedule-template.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/schedule/view-schedule-templates.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/schedule/view-schedule-templates.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 2
+---
+
+# View schedule templates
+
+## Overview
+
+This flow describes how to see the schedule templates of a resource in Care. Use it to check when a practitioner, a location, or a healthcare service is available. See [Schedule & Availability](../../../concepts/scheduling/schedule.mdx).
+
+## Pre-requisites
+
+- The facility is created in Care.
+- The resource is available in the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can list schedule on Object | Lets you see the schedules of the resource. |
+
+## Steps
+
+### 1. Open the schedule of the resource
+
+Open the facility. Go to the scheduling section and select the resource.
+
+### 2. Read the list of templates
+
+The page lists the schedule templates for the selected month. Each template shows its name, its validity period and its sessions.
+
+If the resource has no template for the month, the page shows the message "No schedule templates found for this month."
+
+### 3. Check the visibility of a template
+
+A private template shows the message "This schedule is private". Patients cannot see a private template and cannot book against it.
+
+## Expected Outcome
+
+- You see the schedule templates of the resource for the selected month.
+- You see the sessions in each template, with their times and slot types.
+
+## Related
+
+Concepts:
+
+- [Schedule & Availability](../../../concepts/scheduling/schedule.mdx)
+
+Flows:
+
+- [Create a schedule template](./create-schedule-template.mdx)
+- [Edit a schedule template](./edit-schedule-template.mdx)
+- [Delete a schedule template](./delete-schedule-template.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/token/_category_.json
+++ b/versioned_docs/version-3.1/flows/scheduling/token/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Token",
+  "position": 3,
+  "key": "scheduling-token-flows"
+}

--- a/versioned_docs/version-3.1/flows/scheduling/token/cancel-token.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/token/cancel-token.mdx
@@ -1,0 +1,55 @@
+---
+sidebar_position: 4
+---
+
+# Cancel a token
+
+## Overview
+
+This flow describes how to cancel a token in Care. Use it when the patient leaves, or when staff do not serve the token. See [Token](../../../concepts/scheduling/token.mdx).
+
+## Pre-requisites
+
+- The token is in a queue.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Token | Lets you cancel a token. |
+| Can list token on Object | Lets you see the queue and its tokens. |
+
+## Steps
+
+### 1. Open the queue
+
+Open the facility and select **Queues**. Select the queue that holds the token. See [Manage a token queue](./manage-token-queue.mdx).
+
+### 2. Find the token
+
+Find the token on the **Ongoing** tab.
+
+### 3. Cancel the token
+
+Select **Cancel Token** on that token. Care asks you to confirm.
+
+### 4. Confirm
+
+Select **Cancel Token** to confirm.
+
+## Expected Outcome
+
+- The token status changes to Cancelled.
+- Staff do not call the token in the queue.
+
+## Related
+
+Concepts:
+
+- [Token](../../../concepts/scheduling/token.mdx)
+
+Flows:
+
+- [Create a token](./create-token.mdx)
+- [Manage a token queue](./manage-token-queue.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/token/create-token-category.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/token/create-token-category.mdx
@@ -1,0 +1,58 @@
+---
+sidebar_position: 1
+---
+
+# Create a token category
+
+## Overview
+
+This flow describes how to create a token category for a facility in Care. A category groups tokens, for example by the kind of visit. See [Token](../../../concepts/scheduling/token.mdx).
+
+## Pre-requisites
+
+- The facility is created in Care.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Token Category | Lets you create a token category. |
+| Can list token category on Facility | Lets you see the token categories of the facility. |
+
+## Steps
+
+### 1. Open the facility settings
+
+Open the facility. Go to the settings and select **Token Category**.
+
+### 2. Start a new category
+
+Select the option to create a token category. Care opens the **Create Token Category** form.
+
+### 3. Complete the fields
+
+| Field | What to enter |
+| --- | --- |
+| Name | A descriptive name for the category. This is required. |
+| Shorthand | A short form of the name. Care shows it on the token. This is required. |
+
+### 4. Save the category
+
+Save the form. Care shows the message "Token category created successfully."
+
+## Expected Outcome
+
+- The category appears in the list of token categories for the facility.
+- Staff can select the category when they create a token.
+
+## Related
+
+Concepts:
+
+- [Token](../../../concepts/scheduling/token.mdx)
+
+Flows:
+
+- [Create a token](./create-token.mdx)
+- [Manage a token queue](./manage-token-queue.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/token/create-token.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/token/create-token.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_position: 2
+---
+
+# Create a token
+
+## Overview
+
+This flow describes how to give a token to a patient in Care. The token places the patient in a queue, and staff call the patient in order. See [Token](../../../concepts/scheduling/token.mdx).
+
+## Pre-requisites
+
+- The patient is registered in Care.
+- A token category is created for the facility. See [Create a token category](./create-token-category.mdx).
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create on Token | Lets you create a token. |
+| Can list token category on Facility | Lets you select a token category. |
+
+## Steps
+
+### 1. Start a new token
+
+Select **Create Token**. Care opens the **Create Token** panel.
+
+### 2. Select the resource
+
+Select the resource type, then select the resource. The resource is a practitioner, a location, or a healthcare service.
+
+### 3. Select the category
+
+Select the **Category** for the token.
+
+If the facility has no category, the panel shows the message "No categories found". Create a category first.
+
+### 4. Add a note
+
+Enter a **Note** if you need one. This is optional.
+
+### 5. Save the token
+
+Select **Create Token**. Care shows a message that the token is created.
+
+## Expected Outcome
+
+- Care gives the patient a token number in the queue for the resource.
+- The token appears in the queue with the status Created.
+
+## Related
+
+Concepts:
+
+- [Token](../../../concepts/scheduling/token.mdx)
+
+Flows:
+
+- [Create a token category](./create-token-category.mdx)
+- [Manage a token queue](./manage-token-queue.mdx)
+- [Cancel a token](./cancel-token.mdx)

--- a/versioned_docs/version-3.1/flows/scheduling/token/manage-token-queue.mdx
+++ b/versioned_docs/version-3.1/flows/scheduling/token/manage-token-queue.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+---
+
+# Manage a token queue
+
+## Overview
+
+This flow describes how to work through a token queue in Care. Staff serve patients in order and record when each patient is finished. See [Token](../../../concepts/scheduling/token.mdx).
+
+## Pre-requisites
+
+- A token queue holds at least one token.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can list token on Object | Lets you see the queue and its tokens. |
+| Can Create on Token | Lets you change the status of a token. |
+
+## Steps
+
+### 1. Open the queues
+
+Open the facility and select **Queues**. The page lists the token queues of the facility. The primary queue of a resource shows the **Primary** marker.
+
+### 2. Open a queue
+
+Select the queue that you want to work through.
+
+### 3. Read the tabs
+
+The queue holds two tabs:
+
+| Tab | What it shows |
+| --- | --- |
+| Ongoing | The tokens that wait, and the tokens that staff serve now. |
+| Finished | The tokens that staff finished. The table shows Token Number, Patient Name, Encounter, Service Points and Status. |
+
+Turn on **Auto Refresh** to update the queue without a reload.
+
+### 4. Serve the next patient
+
+Select **Serve Next Patient**. Care moves the next token to In Progress and shows it as the current token.
+
+If the queue has no waiting token, the tab shows that no patient waits.
+
+### 5. Manage the service points
+
+To split the queue between more than one place, select **Manage Service Points**. Each service point serves the queue and records the token that it serves now.
+
+## Expected Outcome
+
+- Staff serve the patients in the order of their token numbers.
+- Finished tokens move to the Finished tab.
+
+## Related
+
+Concepts:
+
+- [Token](../../../concepts/scheduling/token.mdx)
+
+Flows:
+
+- [Create a token](./create-token.mdx)
+- [Cancel a token](./cancel-token.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -117,6 +117,45 @@
               ]
             }
           ]
+        },
+        {
+          "type": "category",
+          "label": "Scheduling",
+          "key": "scheduling-flows",
+          "items": [
+            {
+              "type": "category",
+              "label": "Schedule & Availability",
+              "key": "scheduling-schedule-flows",
+              "items": [
+                "flows/scheduling/schedule/create-schedule-template",
+                "flows/scheduling/schedule/view-schedule-templates",
+                "flows/scheduling/schedule/edit-schedule-template",
+                "flows/scheduling/schedule/delete-schedule-template"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Schedule Exception",
+              "key": "scheduling-exception-flows",
+              "items": [
+                "flows/scheduling/exception/create-schedule-exception",
+                "flows/scheduling/exception/view-schedule-exceptions",
+                "flows/scheduling/exception/remove-schedule-exception"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Token",
+              "key": "scheduling-token-flows",
+              "items": [
+                "flows/scheduling/token/create-token-category",
+                "flows/scheduling/token/create-token",
+                "flows/scheduling/token/manage-token-queue",
+                "flows/scheduling/token/cancel-token"
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## What

Adds documentation for three **Scheduling** modules. These were written from scratch against the backend and frontend sources — they did not exist in `care_docs` before.

### Schedule & Availability

- Replaces `concepts/scheduling/schedule.mdx`
- Four flows: create, view, edit and delete a schedule template

### Schedule Exception (new)

- New concept at `concepts/scheduling/exception.mdx`
- Three flows: create, view and remove a schedule exception

### Token

- Replaces `concepts/scheduling/token.mdx`
- Four flows: create a token category, create a token, manage a token queue, cancel a token

Adds a `Scheduling` category to the 3.1 flows sidebar with the three modules nested under it.

## Where the content comes from

Grounded in:

- `care/emr/models/scheduling/` — `Schedule`, `Availability`, `AvailabilityException`, `SchedulableResource`, `Token`, `TokenQueue`, `TokenSubQueue`, `TokenCategory`
- `care/emr/resources/scheduling/` — field-level specs, enums and validation rules
- `care/security/permissions/schedule.py` and `token.py` — exact permission names
- `care_fe/src/pages/Scheduling/`, `src/pages/Facility/queues/`, `src/components/Tokens/` and `public/locale/en.json` — UI labels

## Please review the flow steps closely

Field names, enums, validation rules and permissions are taken directly from the source and should be accurate. The **step-by-step navigation** in the flows is the weaker part: the entry points ("Open the facility. Go to the scheduling section…") were inferred from the component structure rather than verified by clicking through the product. Anywhere the exact menu path matters, please correct it.

Specifically worth checking:

- How a user reaches the schedule of a resource, and whether the wording matches the UI
- Whether the delete action on a schedule template exists in the UI as described
- The Queues page: tab names, the **Serve Next Patient** action, and how service points are managed
- Whether tokens are usually created from the Create Token panel, from an appointment, or both

## Verification

Docusaurus build passes for both `en` and `ml` locales.
