### PR TITLE
Add Allergy, Condition and medication record docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/clinical/allergy-intolerance.mdx
+++ b/versioned_docs/version-3.1/concepts/clinical/allergy-intolerance.mdx
@@ -1,79 +1,112 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 ---
 
-# Allergy & Intolerance
+# Allergy Intolerance
 
-An **allergy or intolerance** records that a patient reacts badly to a particular substance — a food, a medication, an environmental trigger, or a biologic. It is the standing safety flag that warns clinicians before a harmful exposure happens, and lets the platform check new orders against what a patient cannot tolerate.
+## Definition
 
-## What it represents
+An **[allergy or intolerance](https://build.fhir.org/allergyintolerance.html)** in Care is a substance that causes a reaction in a patient. The substance is a food, a medication, an environmental substance, or a biologic substance. Every allergy belongs to one patient. You record it from an encounter of that patient.
 
-In Care's FHIR-aligned model, this maps to the **AllergyIntolerance** resource. Each record captures:
+## Key Attributes
 
-- **The substance** — a coded allergen drawn from a curated SNOMED CT list, not free text, so it can be matched against medications and other clinical logic
-- **Clinical status** — whether the sensitivity is currently active, inactive, or resolved
-- **Verification status** — how certain the assertion is, from unconfirmed through confirmed, or even refuted or entered in error
-- **Criticality** — the potential for serious harm if the patient is exposed again
-- **Category and type** — what kind of substance it is, and whether it is a true allergy or a non-immune intolerance
-- **Timing and notes** — when it was first recorded, the most recent known reaction, structured onset details, and a free-text clinical note
+| Components | What it captures |
+| --- | --- |
+| Substance | The substance that the patient reacts to. You select it from a standard SNOMED CT allergy terminology. There is no default, so you must select one. |
+| Category | The type of the substance. The default is Medication. |
+| Criticality | The risk of a serious reaction. The default is Low. |
+| Status | How certain the record is. The default is Confirmed. |
+| Clinical Status | The current clinical state of the allergy. The default is Active. |
+| Occurrence | The date when the patient last reacted to the substance. Care does not accept a future date. The default is empty. |
+| Note | Free text about the allergy. The default is empty. |
 
-An allergy record is an assertion about a *risk*, not a log of a reaction that occurred. A single confirmed peanut allergy stays on the record over time even if the patient never reacts again — it is the patient's standing safety profile, distinct from a one-off [Observation](../clinical/observation.mdx) or a documented [Condition](../clinical/condition.mdx).
+### Category
 
-## Type and classification
+The Category shows the type of the substance. Select one of these values:
 
-Two distinctions shape how a record reads:
+- Food
+- Medication
+- Environment
+- Biologic
 
-- **Type** — an **allergy** is an immune-mediated response; an **intolerance** is a non-immune adverse reaction (for example, lactose intolerance). The default is allergy.
-- **Category** — the kind of substance: **food**, **medication**, **environment**, or **biologic**. Category is set when the record is created and is fixed thereafter.
+Note: You cannot change the Category after you save the allergy.
 
-**Criticality** sits alongside these to express stakes — `low`, `high`, or `unable_to_assess` — answering "how dangerous is the next exposure?" rather than "how sure are we this is real?", which is what verification status answers.
+### Criticality
+
+The Criticality shows the risk of a serious reaction. Select one of these values:
+
+- Low
+- High
+- Unable to Assess
+
+### Status
+
+The **Status** column shows how certain the record is. Select one of these values:
+
+| Status | Description |
+| --- | --- |
+| Unconfirmed | Care has no confirmation of the allergy. |
+| Presumed | The allergy is likely, but nobody confirmed it. |
+| Confirmed | Somebody confirmed the allergy. |
+| Refuted | Somebody ruled out the allergy. |
+| Entered in Error | Somebody recorded the allergy by mistake. |
+
+Note: Care offers Entered in Error only for a saved allergy.
+
+### Clinical Status
+
+The Clinical Status shows the current clinical state of the allergy. Set it from the more-options (**⋮**) menu of the row.
+
+| Clinical Status | Description | Menu item |
+| --- | --- | --- |
+| Active | The allergy still applies to the patient. | **Mark Active** |
+| Inactive | The allergy no longer applies to the patient. | **Mark Inactive** |
+| Resolved | The allergy is over. | **Mark Resolved** |
+
+Care shows an inactive allergy in a lighter shade. Care strikes through a resolved allergy.
+
+### Terminology
+
+The substances come from a standard SNOMED CT allergy terminology.
+
+Note: Your deployment's administrator can change the available terminology.
 
 ## Lifecycle
 
-A record carries two independent status axes. Clinical status tracks whether the sensitivity is live; verification status tracks how trustworthy the assertion is.
+You record and change allergies from the **Overview** tab of the encounter. Use the **Allergies** section, or use the **Allergy** quick action.
 
-```text
-Clinical status:      active → inactive → resolved
-Verification status:  unconfirmed → presumed → confirmed
-                                 ↘ refuted / entered_in_error
-```
+While the encounter is open, you can change the Criticality, the Status, the Clinical Status, the Occurrence, and the Note of a saved allergy. You cannot change the Substance or the Category after you save the allergy.
 
-- **active** — the allergy is currently relevant to the patient's care
-- **inactive** — no longer considered active, but kept for history
-- **resolved** — the patient is believed to have outgrown or recovered from the sensitivity
-- **unconfirmed / presumed / confirmed** — increasing levels of certainty that the allergy is real
-- **refuted** — investigated and found not to be a genuine allergy
-- **entered_in_error** — recorded by mistake; flagged so it no longer drives safety logic
+All add and edit controls are read-only when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
 
-These axes move independently: a record can be clinically `active` yet only `unconfirmed`, and a `refuted` allergy is kept rather than deleted so the decision is auditable.
+Care never deletes a saved allergy. To retract one, set its Status to Entered in Error. Care then leaves the allergy out of the **Allergies** section and out of the allergy history.
 
-## How it connects
+Care links each allergy to the encounter where you last recorded or changed it. If you change an allergy from a later encounter, Care keeps the earlier version with the first encounter.
 
-- **Patient** — every allergy belongs to one [patient](../clinical/patient) and is part of their standing clinical profile. The patient is derived automatically and is never set by the client.
-- **Encounter** — each allergy is recorded against the [encounter](../clinical/encounter.mdx) in which a clinician asserted it, anchoring it to a moment in the patient's timeline. Records are tied to both, so an allergy never outlives the patient or encounter it belongs to.
-- **Medications** — because the substance is a code from a curated value set rather than free text, an allergy can be matched against a [medication request](../medications/medication-request.mdx) and other ordering logic, instead of relying on a clinician to read a note.
+Allergies stay with the patient. The allergy history of the patient shows them across all encounters.
 
 ## Permissions
 
-Allergy and intolerance records have no permission file of their own — as patient clinical data, they are governed by the **patient** and **encounter** permissions a user holds in the relevant facility. Recording an allergy is gated by write access to the patient; reading is allowed by the patient's clinical-data permission, or, failing that, by the encounter's clinical-data read permission for a specified encounter; editing is gated by write access to the encounter's clinical data.
+Your role controls what you can do with an allergy.
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_patient` | Create an allergy record — the create path checks write access to the patient | Staff, Doctor, Nurse, Administrator, Admin, Facility Admin |
-| `can_view_clinical_data` | View a patient's clinical data, including their allergies and intolerances | Staff, Doctor, Nurse, Admin, Facility Admin |
-| `can_read_encounter_clinical_data` | Read an encounter's clinical data — the fallback used to reach allergies when patient-level clinical access is absent, scoped to the matching encounter | Admin, Doctor, Nurse, Facility Admin |
-| `can_write_encounter_clinical_data` | Update an allergy record — the update path checks write access to its encounter's clinical data | Admin, Doctor, Nurse, Facility Admin |
+| Permission | What it allows |
+| --- | --- |
+| Can submit questionnaire about patient encounters | Submit the allergy screen of an encounter. |
+| Can Update a Patient's data | Record a new allergy for the patient. |
+| Update Encounter related clinical data | Change or retract an allergy of an encounter. |
+| Can view clinical data about patients | View the allergies of a patient. |
+| Can Read encounter related clinical data | View the allergies of one encounter. |
 
-Roles are granted to users through organization, facility, and patient memberships; permissions cascade down the organization tree, so a role held higher up applies to the facilities and patients beneath it.
+By default, doctors, nurses, administrators, and facility administrators can record and change allergies. Staff can view patient clinical data, but staff do not have encounter clinical-data access.
+
+## FHIR R5 alignment
+
+Care follows FHIR R5 for allergies. The substance, the category, the criticality, the verification status, the clinical status, the last occurrence, and the note map to the FHIR AllergyIntolerance resource.
 
 ## Related
 
-- Reference: [Allergy Intolerance (technical)](../../references/clinical/allergy-intolerance.mdx)
-- Concept: [Patient](../clinical/patient)
-- Concept: [Encounter](../clinical/encounter.mdx)
-- Concept: [Condition](../clinical/condition.mdx)
-- Concept: [Observation](../clinical/observation.mdx)
-
-## FHIR reference
-
-This concept aligns with the FHIR **AllergyIntolerance** resource, which represents a clinician's assertion of a patient's propensity for an adverse reaction to a substance. Care follows its core structure — coded substance, clinical and verification status, criticality, category, and type.
+- Flow: [Record an allergy](../../flows/clinical/allergy-intolerance/record-allergy.mdx)
+- Flow: [Update an allergy](../../flows/clinical/allergy-intolerance/update-allergy.mdx)
+- Flow: [Mark an allergy as entered in error](../../flows/clinical/allergy-intolerance/allergy-entered-in-error.mdx)
+- Flow: [View allergy history](../../flows/clinical/allergy-intolerance/view-allergy-history.mdx)
+- Concept: [Condition](../../concepts/clinical/condition.mdx)

--- a/versioned_docs/version-3.1/concepts/clinical/condition.mdx
+++ b/versioned_docs/version-3.1/concepts/clinical/condition.mdx
@@ -1,76 +1,103 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Condition
 
-A **condition** is a clinical problem recorded for a patient — a diagnosis, a chronic illness, or a presenting symptom. It is how a patient's diagnoses and problem list are captured, giving every clinician a shared, durable view of what the patient is being treated for.
+## Definition
 
-In the Care product UI, conditions are surfaced as **Symptoms**.
+A **[condition](https://build.fhir.org/condition.html)** in Care is a clinical problem that affects a patient. Care records a condition as a symptom or as a diagnosis. A symptom is what the patient reports or the clinician observes. A diagnosis is the clinician's determination of the condition.
 
-## What it represents
+Every symptom and every diagnosis belongs to one patient. You record it against one encounter. You do not select the patient separately, because Care uses the patient of the encounter.
 
-A condition is a *standing statement* about a patient's health, not a one-time reading. A blood pressure value or a lab result is an [observation](../clinical/observation.mdx) — true at the moment it was taken. A condition is a claim the care team is making and tracking: "this patient has diabetes," "this patient presented with chest pain." That claim persists across visits until someone changes its status, which is why a condition needs two things an observation does not — a statement of **how certain** the team is, and a statement of **how the condition is progressing**.
+## Key Attributes
 
-To keep problems comparable across patients and facilities, the condition itself is recorded as a coded clinical finding (drawn from a SNOMED CT vocabulary) rather than free text. Onset, optional severity, the encounter it was noted in, and a free-text note round out the record.
+Symptoms and diagnoses capture the same attributes.
 
-## Classification
+| Components | What it captures |
+| --- | --- |
+| Clinical Term | The clinical term for the condition. You select it from a standard SNOMED CT clinical-finding terminology. There is no default, so you must select one. |
+| Status | The current clinical state of the condition. The default is Active. |
+| Verification | How certain the record is. The default is Confirmed. |
+| Severity | How severe the condition is. The default is Moderate. For a diagnosis you can leave it empty, and the field then shows "Choose severity". |
+| Onset Date | When the condition started. The default is today. Care does not accept a future date. |
+| Note | Free text about the condition. The default is empty. |
 
-The **category** answers "what kind of problem is this, and where does it live in the record?" Every condition is one of:
+### Status
 
-- **Problem-list item** — an ongoing problem the care team is tracking for this patient
-- **Encounter diagnosis** — a diagnosis made or confirmed during a specific visit
-- **Chronic condition** — a long-term condition such as diabetes or hypertension, carried across encounters
+The Status shows the current clinical state of the condition. Select one of these values:
 
-Running alongside the category is a separate axis — the **verification status** — that records certainty. A symptom under investigation might be `unconfirmed`, `provisional`, or `differential`; a settled diagnosis is `confirmed`; something logged in error is `refuted` or `entered_in_error`. Care always requires a verification status, so the record never blurs a working hypothesis with an established fact.
+- Active
+- Recurrence
+- Relapse
+- Inactive
+- Remission
+- Resolved
+
+### Verification
+
+The Verification shows how certain the record is. Select one of these values:
+
+- Unconfirmed
+- Provisional
+- Differential
+- Confirmed
+- Refuted
+- Entered in Error
+
+### Severity
+
+The Severity shows how severe the condition is. Select one of these values:
+
+- Mild
+- Moderate
+- Severe
+
+### Category
+
+A diagnosis also shows a category badge with the label **Diagnosis**. This badge marks the record as specific to that visit.
+
+### Terminology
+
+The clinical terms come from a standard SNOMED CT clinical-finding terminology. The same terminology serves symptoms and diagnoses.
+
+Note: Your deployment's administrator can change the available terminology.
 
 ## Lifecycle
 
-The **clinical status** tracks where a condition stands over time. It is distinct from verification — that is about how sure the team is; this is about the condition's actual course:
+You record symptoms and diagnoses from the **Overview** tab of the encounter. Use the **Symptoms** section and the **Diagnoses** section.
 
-```text
-active → inactive → remission → resolved
-   ↑         |
-   └─ recurrence / relapse ─┘
-```
+You cannot record a symptom or a diagnosis without an active encounter. Without an active encounter, the screen shows "Symptoms cannot be recorded without an active encounter" or "Diagnosis cannot be recorded without an active encounter".
 
-- **active** — currently present and being managed
-- **recurrence** — returned after a symptom-free period
-- **relapse** — returned after being in remission
-- **inactive** — no longer active, but not formally resolved
-- **remission** — symptoms have abated, but the condition may return
-- **resolved** — fully cleared
-- **unknown** — current state is not known
+While the encounter is open, you can change the Status, the Verification, the Severity, and the Note of a saved record. You cannot change the Onset Date after you save the record.
 
-This is not a one-way pipeline. A chronic condition can cycle through active, remission, and recurrence many times over a patient's history.
+Care never deletes a saved symptom or diagnosis. To retract one, set its Verification to Entered in Error. The record stays visible with that label. Care leaves the records with the Verification value Entered in Error out of the **Past Symptoms** list and the **Past Diagnoses** list.
 
-## How it connects
-
-A condition never stands alone — it is always anchored to a patient and the visit where it was noted:
-
-- **Patient** — the person the condition describes. Care derives this automatically from the encounter, so the condition is always attached to the right record; clients never set it directly.
-- **Encounter** — the visit during which the condition was recorded. Every condition is created in the context of an encounter; chronic conditions can later be re-associated with a new encounter as care continues.
-
-Conditions sit alongside the patient's other clinical records — most closely [allergies and intolerances](../clinical/allergy-intolerance.mdx), which capture a different kind of standing risk, and [observations](../clinical/observation.mdx), which capture point-in-time measurements and findings.
+Symptoms and diagnoses stay with the patient. The clinical history of the patient shows them across all encounters. Use the **Past Symptoms** tab and the **Past Diagnoses** tab.
 
 ## Permissions
 
-A condition has no permission file of its own — as patient clinical data, it is governed by the **patient** and **encounter** clinical-data permissions a user holds in the relevant facility. Creating, updating, and deleting a condition is gated by write access to the encounter's clinical data; reading it requires the patient's clinical-data permission, falling back to the encounter's clinical-data read permission. Chronic conditions are a special case — updating one is gated by the patient's clinical-data permission rather than the encounter's. Conditions can also be captured by submitting a symptom or diagnosis questionnaire.
+Your role controls what you can do with a symptom or a diagnosis.
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_encounter_clinical_data` | Create, update, or delete a condition (the create, update, and destroy paths check write access to the encounter's clinical data; chronic-condition updates are the exception below) | Admin, Doctor, Nurse, Facility Admin |
-| `can_view_clinical_data` | Read a patient's conditions, and update a chronic condition (the read path checks the patient's clinical-data permission; chronic-condition updates check this same permission) | Staff, Doctor, Nurse, Admin, Facility Admin |
-| `can_read_encounter_clinical_data` | Read conditions via an encounter when patient-level clinical access is absent (the read path falls back to this when an `encounter` query param is supplied) | Admin, Doctor, Nurse, Facility Admin |
-| `can_submit_patient_questionnaire` | Submit a patient-subject questionnaire (such as symptom or diagnosis), which can record conditions | Volunteer, Staff, Doctor, Nurse, Admin, Facility Admin, Administrator |
-| `can_submit_encounter_questionnaire` | Submit an encounter-linked questionnaire, which can record conditions | Staff, Doctor, Nurse, Admin, Facility Admin |
+| Permission | What it allows |
+| --- | --- |
+| Can view clinical data about patients | View the symptoms and the diagnoses of a patient. |
+| Can Read encounter related clinical data | View the symptoms and the diagnoses of an encounter. |
+| Update Encounter related clinical data | Record and change symptoms and diagnoses. |
 
-Roles are granted to users through facility, organization, or patient memberships, and they cascade down the organization tree — a role held high in the hierarchy applies to the facilities and patients beneath it.
+By default, doctors, nurses, administrators, and facility administrators can record and change clinical data. Staff can view patient clinical data, but staff do not have encounter clinical-data access.
+
+All add and edit controls are read-only when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
+
+## FHIR R5 alignment
+
+Care follows FHIR R5 for conditions. The clinical term, the status, the verification, the severity, the category, the onset date, and the note map to the FHIR Condition resource.
 
 ## Related
 
-- Reference: [Condition (technical)](../../references/clinical/condition.mdx)
-- Concept: [Patient](../clinical/patient)
-- Concept: [Encounter](../clinical/encounter.mdx)
-- Concept: [Allergy / intolerance](../clinical/allergy-intolerance.mdx)
-- Concept: [Observation](../clinical/observation.mdx)
+- Flow: [Record a symptom](../../flows/clinical/condition/record-symptom.mdx)
+- Flow: [Record a diagnosis](../../flows/clinical/condition/record-diagnosis.mdx)
+- Flow: [Add a symptom or diagnosis from past records](../../flows/clinical/condition/add-condition-from-past-records.mdx)
+- Flow: [Update a symptom or diagnosis](../../flows/clinical/condition/update-condition.mdx)
+- Flow: [Mark a symptom or diagnosis as entered in error](../../flows/clinical/condition/condition-entered-in-error.mdx)
+- Flow: [View the clinical history](../../flows/clinical/condition/view-clinical-history.mdx)

--- a/versioned_docs/version-3.1/concepts/medications/medication-administration.mdx
+++ b/versioned_docs/version-3.1/concepts/medications/medication-administration.mdx
@@ -4,76 +4,63 @@ sidebar_position: 2
 
 # Medication Administration
 
-A **medication administration** is the record that a dose was actually given to a patient — or that giving it was attempted and did not happen. It is the moment an order becomes a real event at the bedside, closing the loop on what a clinician prescribed.
+## Definition
 
-## What it represents
+A **[medicine administration](https://build.fhir.org/medicationadministration.html)** in Care
+records a dose of medicine that staff gave to a patient. It is separate from the
+[medication request](../../concepts/medications/medication-request.mdx), which is the order. You record an
+administration against a medicine that is already prescribed on the encounter.
 
-In Care's FHIR-aligned model, this maps to the **MedicationAdministration** resource. A single record answers four questions about one dose: what was given, how and when it was given, who gave it, and — if it was not given — why.
+Care shows the administrations of an encounter in the **Medicine Administration** sub-tab of
+the **Medicines** tab. The sub-tab shows a grid of medicines against six-hour time slots.
 
-The distinction that matters most is between the administration and the order behind it. The order ([Medication Request](../medications/medication-request.mdx)) is the plan: *what should be given*. The administration is the event: *was this dose actually given?* One order produces many administrations over time, one for each scheduled dose, so the two together tell you whether the plan was followed.
+## Key Attributes
 
-This is also why recording a "not given" event matters as much as recording a completed one. It makes a gap in the patient's medication history explicit and auditable, rather than leaving it silent.
+| Components | What it captures |
+| --- | --- |
+| Medicine | The prescribed medicine that this dose belongs to. This field is mandatory. |
+| Status | The state of the dose. See Status below. This field is mandatory. |
+| Start Time | When the dose started. This field is mandatory. Care sets the current date and time by default. |
+| End Time | When the dose ended. This field is optional. |
+| Dosage | The dose, the route, the site, and the method. Care copies these from the prescription. |
+| Administration Notes | Free text about the dose. This field is optional. |
+| Performer | The staff member who gave the dose, and their role in giving it. The administration form does not collect this field. Care records the user who saves the record. |
 
-## Lifecycle
+### Changes after you save
 
-The `status` field tracks what happened to a single dose. A normal administration moves through the active path:
+After you save an administration, the form lets you change only the Status and the
+Administration Notes. You cannot change the medicine, the dosage, the start time, or the end
+time. Care keeps the record when you mark it as Entered in Error.
 
-```text
-in_progress → completed
-            → on_hold → in_progress
-            → stopped
-            → not_done
-```
+## Status
 
-- **in_progress** — the dose has started but is not finished (typical for an infusion still running)
-- **on_hold** — administration was paused and may resume
-- **completed** — the dose was fully given
-- **stopped** — administration was halted before completion
-- **not_done** — the dose was deliberately not given, recorded with a reason
+| Status | Description |
+| --- | --- |
+| In Progress | Staff are giving the dose now. |
+| Completed | Staff gave the dose. |
+| Not Done | Staff did not give the dose. |
+| On Hold | Staff paused the dose. |
+| Stopped | Staff stopped the dose before it finished. |
+| Cancelled | Staff cancelled the dose before they gave it. |
+| Entered in Error | Staff created the record by mistake. |
+| Unknown | The state of the dose is not known. |
 
-Three further statuses are administrative rather than clinical: **cancelled** (the planned dose was called off), **entered_in_error** (the record was a mistake and should be disregarded), and **unknown** (the outcome cannot be determined).
-
-## Classification
-
-The `category` marks the setting in which the dose was given, which drives reporting and reconciliation:
-
-- **inpatient** — given to an admitted patient on a ward
-- **outpatient** — given during a clinic or day visit
-- **community** — given outside the facility, such as a home or field setting
-- **discharge** — supplied or given as the patient leaves
-
-## How it connects
-
-A medication administration sits at the centre of the medication workflow and ties together several other records:
-
-- **Patient** — every administration belongs to a [patient](../clinical/patient). The patient is derived automatically from the encounter, never entered directly, so the record can never drift from the visit it happened in.
-- **Encounter** — the [encounter](../clinical/encounter.mdx) during which the dose was given anchors it in time and place.
-- **Medication Request** — the [order](../medications/medication-request.mdx) this administration fulfils, which is what turns a list of given doses back into "did we follow the plan?".
-- **Product** — when a specific catalogued item was used, the administration points to that [product knowledge](../definitions/product-knowledge.mdx) entry so the dose can be reconciled against supply.
-
-A record names either a coded medication or a specific product, never both. The coded form describes the substance; the product form ties the dose to a real item that left your stores.
+Note: The administration form offers all of these states except Unknown.
 
 ## Permissions
 
-Access to recording and viewing administrations is governed by facility-scoped permissions.
+| Permission | What it allows |
+| --- | --- |
+| Update Encounter related clinical data | Record or update a medicine administration. Held by Doctor, Nurse, Admin, and Facility Admin. |
+| Can view clinical data about patients | View the medicine administrations of a patient. Held by Staff, Doctor, Nurse, Admin, and Facility Admin. |
+| Can Read encounter related clinical data | View the medicine administrations of one encounter. Held by Doctor, Nurse, Admin, and Facility Admin. |
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_encounter_clinical_data` | Create, update, and delete a medication administration on the encounter (write encounter clinical data). Blocked once the encounter is closed | Admin, Doctor, Nurse, Facility Admin |
-| `can_view_clinical_data` | View a patient's clinical data, including listing and retrieving their medication administrations | Staff, Doctor, Nurse, Admin, Facility Admin |
-| `can_read_encounter_clinical_data` | Read an encounter's clinical data; used as the fallback read check when a specific encounter is supplied | Admin, Doctor, Nurse, Facility Admin |
-
-Roles are granted through a user's facility and organization memberships, and permissions cascade down the organization tree — a role held high in the hierarchy carries to the facilities beneath it.
+To record or change an administration, you also need an open encounter. Care blocks changes when
+the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
 
 ## Related
 
-- Reference: [Medication Administration (technical)](../../references/medications/medication-administration.mdx)
-- Concept: [Medication Request](../medications/medication-request.mdx)
-- Concept: [Medication Dispense](../medications/medication-dispense.mdx)
-- Concept: [Medication Statement](../medications/medication-statement.mdx)
-- Concept: [Encounter](../clinical/encounter.mdx)
-- Concept: [Product Knowledge](../definitions/product-knowledge.mdx)
-
-## FHIR reference
-
-This concept aligns with the FHIR [MedicationAdministration](https://hl7.org/fhir/medicationadministration.html) resource, which records the consumption or administration of a medication to a patient.
+- Flow: [Administer a dose](../../flows/medications/medication-administration/administer-dose.mdx)
+- Flow: [View the medicine administration record](../../flows/medications/medication-administration/view-medicine-administration.mdx)
+- Flow: [Update an administration record](../../flows/medications/medication-administration/update-administration-record.mdx)
+- Concept: [Medication Request](../../concepts/medications/medication-request.mdx)

--- a/versioned_docs/version-3.1/concepts/medications/medication-dispense.mdx
+++ b/versioned_docs/version-3.1/concepts/medications/medication-dispense.mdx
@@ -4,82 +4,61 @@ sidebar_position: 3
 
 # Medication Dispense
 
-A **medication dispense** is the record of a product being handed over to a patient — the moment a prescription turns into medicine in someone's hands. It closes the loop between what was ordered and what the patient received, and it draws the dispensed quantity down from your pharmacy's stock.
+## Definition
 
-## What it represents
+A **[medicine dispense](https://build.fhir.org/medicationdispense.html)** in Care is the record of
+a medicine or a supply item that the pharmacy gives to a patient. The pharmacy gives the item
+from the facility's stock. A medicine dispense is separate from the
+[medication request](../../concepts/medications/medication-request.mdx), which is the order.
 
-In Care's FHIR-aligned model, a medication dispense maps to the **MedicationDispense** resource. Each dispense captures:
+## Key Attributes
 
-- **What was given** — the inventory item handed over and the quantity, optionally with how many days it should last
-- **When and how** — when the product was prepared, when it was handed over, and any dosage instructions or notes
-- **Why it may not have happened** — a coded reason when a dispense is declined or cannot be completed (out of stock, allergy, drug interaction, and similar)
-- **Substitution** — whether a different product was supplied in place of the one prescribed, and why
-- **Context** — the patient, encounter, location it was dispensed from, and the prescription it fulfils
+| Components | What it captures |
+| --- | --- |
+| Item | The inventory item that the pharmacy dispenses. This field is mandatory. |
+| Quantity | How many units the pharmacy dispenses. This field is mandatory. |
+| Days Supply | How many days the quantity lasts. This field is optional. |
+| Location | The facility location that the pharmacy dispenses the item from. This field is mandatory. |
+| Authorizing Request | The medication request that this dispense fulfills. This field is optional. |
+| Status | The current state of the dispense. See Status below. This field is mandatory. |
+| When Prepared / When Handed Over | When the pharmacy prepared the item and handed it over. These fields are optional. |
+| Note | Free text notes about the dispense. This field is optional. |
 
-A dispense is not a prescription, and it is not an administration. A [medication request](../medications/medication-request.mdx) is the *intent* to give a drug; a dispense is the *act* of supplying it; a [medication administration](../medications/medication-administration.mdx) records the drug actually entering the body. One prescription can be filled by several dispenses over time, which is why these three are kept distinct.
+Note: A dispense can belong to a Dispense Order. A Dispense Order groups the items that the
+pharmacy dispenses for a patient at one time. A Prescription groups medication requests in the
+same way. Care names a Dispense Order after the date and time of the dispense when the order
+has no name.
 
-## How it connects
+## Status
 
-A dispense sits where clinical orders, pharmacy stock, and billing meet:
+| Status | Description |
+| --- | --- |
+| Preparation | The pharmacy prepares the item. |
+| In Progress | The dispense is in progress. |
+| Completed | The pharmacy hands over the item. |
+| On Hold | The dispense is paused. |
+| Cancelled | Staff cancel the dispense. Care restores the quantity to stock. |
+| Stopped | Staff stop the dispense. Care restores the quantity to stock. |
+| Declined | Staff decline the dispense. Care restores the quantity to stock. |
+| Entered in Error | Staff record the dispense by mistake. Care restores the quantity to stock. |
 
-- **Authorizing request** — the [medication request](../medications/medication-request.mdx) it fulfils. Marking a dispense as fully or partially dispensed updates the prescription so it is not filled again by mistake.
-- **Inventory item** — the specific stock item consumed. Dispensing draws its quantity down, and Care blocks the dispense when there is not enough stock.
-- **Charge item** — when the product is priced, Care automatically creates a [charge item](../../references/billing/charge-item.mdx) so the dispense flows through to billing. Cancelling the dispense cancels its charge.
-- **Encounter, patient, and location** — every dispense belongs to a patient's [encounter](../clinical/encounter.mdx) and is supplied from a [location](../../references/facility/location.mdx) within the facility.
+Note: When you dispense from the **Dispense History** sub-tab of an encounter, Care sets the
+status to Completed.
 
-## Categories
-
-A dispense is classified by where care is happening, which shapes how the workflow runs:
-
-- **Inpatient** — dispensed to a patient in a bed or room, often refilled as the stay continues
-- **Outpatient** — dispensed at the pharmacy counter, typically after an encounter wraps up
-- **Discharge** — supplied as a patient leaves, to continue treatment at home
-- **Community** — dispensed in a field or community setting, outside the facility walls
-
-## Dispense orders
-
-Individual dispenses at a location can be grouped into a **dispense order** — a named bundle that carries one shared status. This lets a pharmacy treat a batch of items as a single unit of work: filling them together, tracking them together, and cancelling them together. Cancelling an order cascades to every dispense inside it, releasing their charges and reopening the prescriptions they were filling.
-
-## Lifecycle
-
-A dispense moves through a status that reflects where the product is on its way to the patient:
-
-```text
-preparation → in_progress → completed
-                  ↓
-   on_hold / cancelled / stopped / declined / entered_in_error
-```
-
-- **preparation** — being readied, not yet handed over
-- **in_progress** — actively being dispensed
-- **on_hold** — paused, can resume later
-- **completed** — handed over to the patient; the dispense is done
-- **declined** — the patient or staff declined the dispense
-- **stopped** — halted before completion and will not resume
-- **cancelled** — called off
-- **entered_in_error** — recorded by mistake and voided
-
-The last four — **cancelled**, **stopped**, **declined**, and **entered_in_error** — are terminal. Once a dispense reaches one of them it can no longer be edited, any attached charge item is cancelled, and the prescription it was filling is reopened so it can be dispensed again.
+Note: Care has no separate return action. To reverse a dispense and put the quantity back in
+stock, change its status to Cancelled, Stopped, Declined, or Entered in Error.
 
 ## Permissions
 
-Dispensing is gated by facility-level permissions. Pharmacists are granted dedicated access so they can fill prescriptions even without broader clinical access to the encounter.
-
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `write_medication_dispense` | Create and update medication dispenses (creates and updates authorize against the dispensing location) | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
-| `read_medication_dispense` | Read medication dispenses, by location or by encounter | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
-
-Roles are granted through a user's facility and organization memberships, and they cascade down the organization tree — a role held high in the hierarchy carries to the facilities and locations beneath it.
+| Permission | What it allows |
+| --- | --- |
+| Medication Dispense Read | View dispense records. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist hold this permission. |
+| Write Medication Dispense | Dispense an item, or change a dispense record. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist hold this permission. |
+| Can Read Supply Delivery | View a Dispense Order. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist hold this permission. |
+| Can Create Supply Delivery on Facility | Create or change a Dispense Order. Only Facility Admin and Admin hold this permission. |
 
 ## Related
 
-- Reference: [Medication Dispense (technical)](../../references/medications/medication-dispense.mdx)
-- Reference: [Medication Request](../../references/medications/medication-request.mdx)
-- Concept: [Medication Administration](../medications/medication-administration.mdx)
-- Concept: [Inventory Item](../supply/inventory-item.mdx)
-- Reference: [Charge Item](../../references/billing/charge-item.mdx)
-
-## FHIR reference
-
-This concept aligns with the FHIR [MedicationDispense](https://www.hl7.org/fhir/medicationdispense.html) resource. Care uses underscored status values (for example `in_progress`, `entered_in_error`) rather than the FHIR hyphenated forms, and some field names differ — Care's authorizing request corresponds to FHIR's `authorizingPrescription`.
+- Flow: [Dispense a medication](../../flows/medications/medication-dispense/dispense-medication.mdx)
+- Flow: [View dispense history](../../flows/medications/medication-dispense/view-dispense-history.mdx)
+- Concept: [Medication Request](../../concepts/medications/medication-request.mdx)

--- a/versioned_docs/version-3.1/concepts/medications/medication-statement.mdx
+++ b/versioned_docs/version-3.1/concepts/medications/medication-statement.mdx
@@ -4,66 +4,73 @@ sidebar_position: 4
 
 # Medication Statement
 
-A **medication statement** is a record of what a patient is actually taking, has taken, or intends to take — as *reported*, not as ordered by your facility. It captures the real-world medication picture: drugs started at another hospital, over-the-counter products, and what a patient or relative tells you during a visit.
+## Definition
 
-## What it represents
+A **[medication statement](https://build.fhir.org/medicationstatement.html)** in Care records a
+medicine that a patient reports taking, or has taken on an ongoing basis. Unlike a
+[medication request](../../concepts/medications/medication-request.mdx), a medication statement is not an order.
+It records what the patient says they take, not what staff prescribe. Care records every
+medication statement against an encounter of the patient.
 
-In Care's FHIR-aligned model, a medication statement maps to the **MedicationStatement** resource. The key distinction is its source of truth: a statement is a *snapshot of reality*, not an instruction. It does not order, supply, or administer anything.
+## Key Attributes
 
-So every statement carries two things a prescription does not: a single coded drug taken from a SNOMED CT value set rather than free text, and an explicit account of *who said so* — the patient, a relative, or a clinician. Around that core it records the status, the period the drug is or was taken, free-text dosage instructions, and the encounter it was recorded in.
-
-If your facility is actively prescribing a drug, that belongs in a [medication request](../medications/medication-request.mdx). Reach for a statement when the source of truth lives outside that order — a home medication list, a drug started elsewhere, or a patient's own account of what they take.
-
-## Lifecycle
-
-A statement carries a single current status that reflects the patient's relationship to the medication. It is not a running log — updating the status replaces the previous value, and only the status, period, and notes can change after creation.
-
-```text
-intended → active → on_hold → completed / stopped
-                              not_taken / unknown / entered_in_error
-```
-
-- **intended** — the patient plans to take the medication but has not started
-- **active** — the medication is currently being taken
-- **on_hold** — taking has been paused
-- **completed** — the course has finished as expected
-- **stopped** — the medication was stopped before completion
-- **not_taken** — the patient is not taking the medication
-- **unknown** — the status could not be determined
-- **entered_in_error** — the record was created by mistake and should be disregarded
-
-## Information source
-
-Because a statement is reported rather than ordered, it always names its source. This is what separates a self-reported or second-hand account from a managed prescription, and it tells a clinician how much to trust the entry.
-
-| Source | Meaning |
+| Components | What it captures |
 | --- | --- |
-| Patient | The patient self-reported it |
-| Related person | A relative or carer reported it |
-| Practitioner | A clinician recorded it on the patient's behalf |
+| Medication | The medicine that the patient takes. This field is mandatory. You cannot change it after you save the entry. |
+| Source | Who reported the medicine: the **Patient**, a **Practitioner**, or a **Related Person**. Care selects **Patient** by default. You cannot change it after you save the entry. |
+| Status | The current state of the statement. See Status below. This field is mandatory. You can change it after you save the entry. |
+| Dosage Instructions | Free text that describes how the patient takes the medicine. This field is mandatory. You cannot change it after you save the entry. |
+| Medication Taken Between | The start date and the end date of the period in which the patient takes the medicine. The start date is mandatory. The end date is optional. Care shows **Ongoing** when there is no end date. You cannot change these dates after you save the entry. |
+| Reason | Why the patient takes the medicine, as free text of up to 100 characters. This field is optional. You cannot change it after you save the entry. |
+| Note | Free text about the medicine. This field is optional. You can change it after you save the entry. |
 
-## How it connects
+### Where Care shows medication statements
 
-- **Patient** — every statement is about one [patient](../clinical/patient). The patient is derived automatically from the encounter, so it is never set by hand.
-- **Encounter** — a statement is recorded within an [encounter](../clinical/encounter.mdx), anchoring it to a specific visit and clinician.
-- **Medication request** — the active-order counterpart. Use a [medication request](../medications/medication-request.mdx) when your facility is the one prescribing; use a statement to capture everything else.
+Care shows the medication statements of a patient in two places. The **Medication Statements**
+sub-tab of the **Medicines** tab shows them during an encounter. The **Past Medications** section
+of the patient's **Clinical History** tab shows them by date.
+
+Both places list every medication statement of the patient. They do not list only the statements
+of one encounter.
+
+## Status
+
+| Status | Description |
+| --- | --- |
+| Active | The patient currently takes the medicine. |
+| On Hold | The patient has paused the medicine. |
+| Completed | The patient finished the course. |
+| Stopped | The patient stopped the medicine before finishing. |
+| Intended | The patient plans to take the medicine. |
+| Not Taken | The patient did not take the medicine. |
+| Unknown | The state is not known. |
+| Entered in Error | Staff recorded the statement by mistake. |
+
+Care offers the **Entered in Error** status only for a statement that you saved. Care keeps a
+statement with this status, but hides it from the **Medication Statements** sub-tab and from
+**Past Medications**.
 
 ## Permissions
 
-Access to medication statements is governed by the clinical-data permissions on the encounter and patient. Creating, updating, and deleting a statement all require write access to the encounter's clinical data, while listing and reading require view access to the patient's clinical data (or, when filtered by encounter, read access to that encounter's clinical data).
+| Permission | What it allows |
+| --- | --- |
+| Update Encounter related clinical data | Record, update, or retract a medication statement. |
+| Can submit questionnaire about patients | Open the form that records a medication statement. |
+| Can view questionnaire responses on patient | Open the **Updates** tab of the patient. |
+| Can view clinical data about patients | View the medication statements of a patient. |
+| Can Read encounter related clinical data | Read the clinical records of the encounter. |
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_write_encounter_clinical_data` | Create, update, or delete a medication statement on an open encounter | Admin, Doctor, Nurse, Facility Admin |
-| `can_view_clinical_data` | View a patient's clinical data, the primary gate for listing and reading statements | Staff, Doctor, Nurse, Admin, Facility Admin |
-| `can_read_encounter_clinical_data` | Read an encounter's clinical data, the fallback gate when results are filtered to a specific encounter | Admin, Doctor, Nurse, Facility Admin |
+To record, change, or retract a medication statement, you also need an open encounter. Care
+blocks these actions when the encounter status is Completed, Cancelled, Discontinued, or
+Entered in Error.
 
-Roles are granted through a user's organization and facility memberships, and permissions cascade down the organization tree — a role held at a parent organization applies to the facilities and patients beneath it.
+Note: After you save a medication statement, you can only change its **Status** and its **Note**.
+The medicine, the source, the dosage instructions, the period, and the reason stay fixed.
 
 ## Related
 
-- Reference: [Medication Statement (technical)](../../references/medications/medication-statement.mdx)
-- Concept: [Medication Request](../medications/medication-request.mdx)
-- Concept: [Medication Administration](../medications/medication-administration.mdx)
-- Concept: [Patient](../clinical/patient)
-- Concept: [Encounter](../clinical/encounter.mdx)
+- Flow: [Record a medication statement](../../flows/medications/medication-statement/record-medication-statement.mdx)
+- Flow: [View medication statements for an encounter](../../flows/medications/medication-statement/view-medication-statements.mdx)
+- Flow: [Update a medication statement](../../flows/medications/medication-statement/update-medication-statement.mdx)
+- Flow: [Mark a medication statement as entered in error](../../flows/medications/medication-statement/medication-statement-entered-in-error.mdx)
+- Concept: [Medication Request](../../concepts/medications/medication-request.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/_category_.json
+++ b/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Allergy Intolerance",
+  "position": 3,
+  "key": "clinical-allergy-intolerance-flows"
+}

--- a/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/allergy-entered-in-error.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/allergy-entered-in-error.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 3
+---
+
+# Mark an allergy as entered in error
+
+## Overview
+
+This flow describes how to retract an [allergy](../../../concepts/clinical/allergy-intolerance.mdx) that somebody recorded by mistake.
+
+## Pre-requisites
+
+- The patient has a saved allergy.
+- The patient has an open encounter at the facility, and you retract the allergy from that encounter.
+- The encounter is not Completed, Cancelled, Discontinued, or Entered in Error. In these states, all add and edit controls are read-only.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can submit questionnaire about patient encounters | Lets you submit the allergy screen of the encounter. |
+| Update Encounter related clinical data | Lets you retract an allergy of the encounter. |
+| Can view clinical data about patients | Lets you see the allergies of the patient. |
+
+## Steps
+
+### 1. Open the allergy screen
+
+Open the encounter. Go to the **Overview** tab. Find the **Allergies** section. Select the edit (pencil) icon.
+
+You can also press the keyboard shortcut **a** on any encounter screen.
+
+### 2. Find the allergy
+
+Find the row of the allergy in the table.
+
+### 3. Mark the allergy as entered in error
+
+Open the more-options (**⋮**) menu of the row. Select **Remove Allergy**.
+
+You can also set the **Status** of the row to **Entered in Error**.
+
+Note: For a saved allergy, **Remove Allergy** sets the Status to Entered in Error. For a new row that you did not submit, **Remove Allergy** deletes the row.
+
+### 4. Submit
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- Care keeps the allergy, with the Status Entered in Error.
+- Care leaves the allergy out of the **Allergies** section of the encounter.
+- Care leaves the allergy out of the allergy history of the patient.
+- The more-options (**⋮**) menu of the row now shows **Already marked as error**.
+
+Note: Care has no separate delete action for an allergy. Entered in Error is the only way to retract one.
+
+## Related
+
+Concepts:
+
+- [Allergy](../../../concepts/clinical/allergy-intolerance.mdx)
+
+Flows:
+
+- [Record an allergy](./record-allergy.mdx)
+- [Update an allergy](./update-allergy.mdx)
+- [View allergy history](./view-allergy-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/record-allergy.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/record-allergy.mdx
@@ -1,0 +1,106 @@
+---
+sidebar_position: 1
+---
+
+# Record an allergy
+
+## Overview
+
+This flow describes how to record an [allergy or intolerance](../../../concepts/clinical/allergy-intolerance.mdx) for a patient during an encounter in Care.
+
+## Pre-requisites
+
+- The patient has an open encounter at the facility, and you record the allergy from that encounter.
+- The encounter is not Completed, Cancelled, Discontinued, or Entered in Error. In these states, all add and edit controls are read-only.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can submit questionnaire about patient encounters | Lets you submit the allergy screen of the encounter. |
+| Can Update a Patient's data | Lets you record a new allergy for the patient. |
+| Can view clinical data about patients | Lets you see the allergies of the patient. |
+
+## Steps
+
+### 1. Open the allergy screen
+
+Open the encounter. Go to the **Overview** tab. Select the **Allergy** quick action.
+
+You can also press the keyboard shortcut **a** on any encounter screen.
+
+You can also find the **Allergies** section and select the edit (pencil) icon.
+
+The allergy screen shows the allergies that the patient already has.
+
+### 2. Search for the substance
+
+Select **Add Allergy**. For each further allergy, the control reads **Add another Allergy**.
+
+Type the name of the substance that the patient reacts to.
+
+The results come from a standard SNOMED CT allergy terminology.
+
+Note: Your administrator sets the clinical terminology for your deployment. Your administrator can also change it.
+
+### 3. Select the term
+
+Select a term. A new row appears with these default values:
+
+| Component | Default |
+| --- | --- |
+| Category | Medication |
+| Criticality | Low |
+| Status | Confirmed |
+| Clinical Status | Active |
+
+### 4. Change the values
+
+Change the values of the row if you need to.
+
+| Component | Options |
+| --- | --- |
+| Category | Food, Medication, Environment, Biologic |
+| Criticality | Low, High, Unable to Assess |
+| Status | Unconfirmed, Presumed, Confirmed, Refuted |
+| Occurrence | Any date up to today |
+
+To change the clinical state, open the more-options (**⋮**) menu of the row. Select **Mark Inactive** or **Mark Resolved**.
+
+Note: Care does not offer Entered in Error for a new allergy.
+
+### 5. Add a note
+
+To add a note, open the more-options (**⋮**) menu of the row. Select **Add notes**. Type the note.
+
+Select **Show notes** to open the note text. Select **Hide notes** to close the note text.
+
+### 6. Add more allergies
+
+Repeat from step 2 for each further allergy.
+
+### 7. Submit
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- Care returns you to the **Overview** tab of the encounter.
+- The allergy appears in the **Allergies** section of the encounter **Overview** tab.
+- The allergy appears in the allergy history of the patient.
+
+When the patient has no allergy, the encounter shows no **Allergies** section.
+
+## Related
+
+Concepts:
+
+- [Allergy](../../../concepts/clinical/allergy-intolerance.mdx)
+
+Flows:
+
+- [Update an allergy](./update-allergy.mdx)
+- [Mark an allergy as entered in error](./allergy-entered-in-error.mdx)
+- [View allergy history](./view-allergy-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/update-allergy.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/update-allergy.mdx
@@ -1,0 +1,77 @@
+---
+sidebar_position: 2
+---
+
+# Update an allergy
+
+## Overview
+
+This flow describes how to change the values of a saved [allergy](../../../concepts/clinical/allergy-intolerance.mdx) in Care.
+
+## Pre-requisites
+
+- The patient has a saved allergy.
+- The patient has an open encounter at the facility, and you change the allergy from that encounter.
+- The encounter is not Completed, Cancelled, Discontinued, or Entered in Error. In these states, all add and edit controls are read-only.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can submit questionnaire about patient encounters | Lets you submit the allergy screen of the encounter. |
+| Update Encounter related clinical data | Lets you change an allergy of the encounter. |
+| Can view clinical data about patients | Lets you see the allergies of the patient. |
+
+## Steps
+
+### 1. Open the allergy screen
+
+Open the encounter. Go to the **Overview** tab. Find the **Allergies** section. Select the edit (pencil) icon.
+
+You can also press the keyboard shortcut **a** on any encounter screen.
+
+The allergy screen shows the allergies that the patient already has.
+
+### 2. Find the allergy
+
+Find the row of the allergy in the table.
+
+### 3. Change the values
+
+Change the values of the row. You can change these values of a saved allergy:
+
+| Component | Options |
+| --- | --- |
+| Criticality | Low, High, Unable to Assess |
+| Status | Unconfirmed, Presumed, Confirmed, Refuted, Entered in Error |
+| Occurrence | Any date up to today |
+| Note | Free text |
+
+To change the clinical state, open the more-options (**⋮**) menu of the row. Select **Mark Active**, **Mark Inactive**, or **Mark Resolved**.
+
+To change the note, open the more-options (**⋮**) menu of the row. Select **Add notes** or **Show notes**.
+
+Note: You cannot change the Substance or the Category of a saved allergy. To correct one of these, record a new allergy. Then mark the incorrect allergy as entered in error.
+
+### 4. Submit
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- Care returns you to the **Overview** tab of the encounter.
+- The **Allergies** section shows the new values.
+
+## Related
+
+Concepts:
+
+- [Allergy](../../../concepts/clinical/allergy-intolerance.mdx)
+
+Flows:
+
+- [Record an allergy](./record-allergy.mdx)
+- [Mark an allergy as entered in error](./allergy-entered-in-error.mdx)
+- [View allergy history](./view-allergy-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/view-allergy-history.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/allergy-intolerance/view-allergy-history.mdx
@@ -1,0 +1,48 @@
+---
+sidebar_position: 4
+---
+
+# View allergy history
+
+## Overview
+
+This flow describes how to view a patient's [allergy](../../../concepts/clinical/allergy-intolerance.mdx) history across their encounters in Care.
+
+## Pre-requisites
+
+- The patient is registered in Care.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | Lets you view a patient's allergies. |
+
+## Steps
+
+### 1. Open the allergy section
+
+On the encounter's Overview tab, or on the patient's record, find the Allergies panel.
+
+### 2. Open the history
+
+Select the history icon on the Allergies panel.
+
+### 3. Review the history
+
+Care shows every allergy recorded for the patient, grouped by date.
+
+## Expected Outcome
+
+- You see the patient's full allergy history, across every encounter.
+
+## Related
+
+Concepts:
+
+- [Allergy](../../../concepts/clinical/allergy-intolerance.mdx)
+
+Flows:
+
+- [Record an allergy](./record-allergy.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/condition/_category_.json
+++ b/versioned_docs/version-3.1/flows/clinical/condition/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Condition",
+  "position": 4,
+  "key": "clinical-condition-flows"
+}

--- a/versioned_docs/version-3.1/flows/clinical/condition/add-condition-from-past-records.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/condition/add-condition-from-past-records.mdx
@@ -1,0 +1,82 @@
+---
+sidebar_position: 3
+---
+
+# Add a symptom or diagnosis from past records
+
+## Overview
+
+This flow describes how to bring the earlier symptoms or diagnoses of a patient into the current encounter. You select the records that you want, instead of searching for each term again. Care stores each of these records as a [condition](../../../concepts/clinical/condition.mdx).
+
+## Pre-requisites
+
+- The patient has an open encounter at the facility, and that encounter is the patient's active encounter.
+- You or a colleague recorded symptoms or diagnoses for the patient in an earlier encounter.
+- The encounter is not Completed, Cancelled, Discontinued, or Entered in Error. In these states, all add and edit controls are read-only.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | View the symptoms and the diagnoses of the patient. |
+| Can Read encounter related clinical data | View the symptoms and the diagnoses of the encounter. |
+| Update Encounter related clinical data | Add symptoms and diagnoses to the encounter. |
+
+## Steps
+
+### 1. Open the symptom screen or the diagnosis screen
+
+Go to the **Overview** tab of the encounter.
+
+For symptoms, select the edit (pencil) icon in the **Symptoms** section. You can also press the keyboard shortcut **s**.
+
+For diagnoses, select the edit (pencil) icon in the **Diagnoses** section. You can also press the keyboard shortcut **d**.
+
+### 2. Open the past records dialog
+
+Select **Symptom History** or **Diagnosis History**.
+
+A dialog opens with the title **Past Symptoms** or **Past Diagnoses**. The dialog lists the records of the patient from all encounters. The dialog leaves out the records with the Verification value Entered in Error.
+
+Note: If the patient has nothing to show, the dialog shows "No Records Found".
+
+### 3. Select the records
+
+Select the checkbox of each record that you want. The dialog shows the count under **Selected**.
+
+If the list is longer than one page, select **Load More** to see more records.
+
+### 4. Add the records
+
+Select **Add Selected**.
+
+To leave the dialog without adding anything, select **Cancel**.
+
+Care adds the selected records to the list of the current encounter.
+
+### 5. Review and submit
+
+Change the Status, the Verification, the Severity, and the Note of each added record if you need to.
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- The added records appear in the **Symptoms** section or the **Diagnoses** section of the encounter **Overview** tab.
+- If you select a term that the encounter already has, Care shows "Symptom already exists!" or "Diagnosis already exists!". Care does not add a second row.
+
+## Related
+
+Concepts:
+
+- [Condition](../../../concepts/clinical/condition.mdx)
+
+Flows:
+
+- [Record a symptom](./record-symptom.mdx)
+- [Record a diagnosis](./record-diagnosis.mdx)
+- [Update a symptom or diagnosis](./update-condition.mdx)
+- [Mark a symptom or diagnosis as entered in error](./condition-entered-in-error.mdx)
+- [View the clinical history](./view-clinical-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/condition/condition-entered-in-error.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/condition/condition-entered-in-error.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 5
+---
+
+# Mark a symptom or diagnosis as entered in error
+
+## Overview
+
+This flow describes how to retract a symptom or a diagnosis that you recorded by mistake. Care stores each of them as a [condition](../../../concepts/clinical/condition.mdx). Care never deletes a saved clinical record. Care keeps the record and sets its Verification to Entered in Error, so the clinical history stays complete.
+
+## Pre-requisites
+
+- You or a colleague recorded the symptom or the diagnosis on the encounter.
+- The encounter is the patient's active encounter.
+- The encounter status is not Completed, Cancelled, Discontinued, or Entered in Error.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | View the symptoms and the diagnoses of the patient. |
+| Can Read encounter related clinical data | View the symptoms and the diagnoses of the encounter. |
+| Update Encounter related clinical data | Set the Verification of a symptom or a diagnosis to Entered in Error. |
+
+## Steps
+
+### 1. Open the symptom screen or the diagnosis screen
+
+Start from the **Overview** tab of the encounter.
+
+- For a symptom, select the edit (pencil) icon in the **Symptoms** section. You can also press the keyboard shortcut **s**.
+- For a diagnosis, select the edit (pencil) icon in the **Diagnoses** section. You can also press the keyboard shortcut **d**.
+
+### 2. Find the row to retract
+
+Find the row of the symptom or the diagnosis that you want to retract.
+
+### 3. Open the more-options menu
+
+Select the more-options (**⋮**) menu of the row.
+
+### 4. Select the remove action
+
+Select the remove action. For a symptom, the action reads **Remove Symptom**.
+
+What happens next depends on the record:
+
+- If you did not submit the record yet, Care removes the row from the list. Care keeps no record of it.
+- If the record is already saved, Care sets its Verification to Entered in Error. The row stays in the list with that label.
+
+Note: After Care sets the Verification of a saved record to Entered in Error, the remove action is unavailable. The tooltip of the action reads "Already marked as error".
+
+### 5. Submit the change
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- The record keeps the Verification value Entered in Error.
+- Care leaves the records with the Verification value Entered in Error out of the **Past Symptoms** list and the **Past Diagnoses** list. You do not carry them into a later encounter.
+- To record the correct information, add a new symptom or a new diagnosis.
+
+Note: The Entered in Error value does not show in the Verification list of a normal record. You set this value only with the remove action.
+
+## Related
+
+Concepts:
+
+- [Condition](../../../concepts/clinical/condition.mdx)
+
+Flows:
+
+- [Record a symptom](./record-symptom.mdx)
+- [Record a diagnosis](./record-diagnosis.mdx)
+- [Add a symptom or diagnosis from past records](./add-condition-from-past-records.mdx)
+- [Update a symptom or diagnosis](./update-condition.mdx)
+- [View the clinical history](./view-clinical-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/condition/record-diagnosis.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/condition/record-diagnosis.mdx
@@ -1,0 +1,118 @@
+---
+sidebar_position: 2
+---
+
+# Record a diagnosis
+
+## Overview
+
+This flow describes how to record one or more diagnoses for a patient during an encounter. Care stores each diagnosis as a [condition](../../../concepts/clinical/condition.mdx).
+
+## Pre-requisites
+
+- The patient has an open encounter at the facility, and that encounter is the patient's active encounter. Without an active encounter, the screen shows "Diagnosis cannot be recorded without an active encounter".
+- The encounter is not Completed, Cancelled, Discontinued, or Entered in Error. In these states, all add and edit controls are read-only.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | Lets you open the clinical data of the encounter. |
+| Can Read encounter related clinical data | Lets you see the diagnoses of the encounter. |
+| Update Encounter related clinical data | Lets you record a diagnosis. |
+
+Doctors, nurses, administrators, and facility administrators have the Update Encounter related clinical data permission by default.
+
+Without view access, the encounter shows "You do not have permission to view clinical data for this encounter".
+
+## Steps
+
+### 1. Open the diagnosis screen
+
+Open the encounter. Go to the **Overview** tab. Find the **Diagnoses** section. Select the edit (pencil) icon.
+
+You can also press the keyboard shortcut **d** on any encounter screen. The shortcut opens the same diagnosis screen.
+
+The diagnosis screen shows the diagnoses that the encounter already has.
+
+### 2. Start a new diagnosis
+
+Select **Add Diagnosis**. For each further diagnosis, the control reads **Add another Diagnosis**.
+
+### 3. Search for the diagnosis
+
+A search box opens. Type a minimum of 3 characters. The screen shows a message below the search box that tells you the minimum length.
+
+The results come from a standard SNOMED CT clinical-finding terminology.
+
+The search box has two tabs:
+
+- **Search**: the terms that match the text that you type.
+- **Starred**: the terms that you pinned. Select the star icon on a result to pin it.
+
+Note: Your administrator sets the clinical terminology for your deployment. Your administrator can also change it.
+
+### 4. Select the term
+
+Select a term. A new row appears with these default values:
+
+| Component | Default |
+| --- | --- |
+| Status | Active |
+| Verification | Confirmed |
+| Severity | Moderate |
+| Onset Date | Today |
+
+The row shows a badge with the label **Diagnosis**. This badge marks the record as specific to this visit.
+
+### 5. Change the values
+
+Change the values of the row if you need to.
+
+| Component | What it captures |
+| --- | --- |
+| Status | The current state of the diagnosis: Active, Recurrence, Relapse, Inactive, Remission, or Resolved. The placeholder reads "Select diagnosis status". |
+| Verification | The certainty of the diagnosis: Unconfirmed, Provisional, Differential, Confirmed, or Refuted. The placeholder reads "Select verification status". |
+| Severity | The severity of the diagnosis: Mild, Moderate, or Severe. You can leave this field empty. The field then shows "Choose severity". |
+| Onset Date | The date when the diagnosis started. Care does not accept a future date. |
+
+Note: Care does not offer Entered in Error as a verification value for a new diagnosis.
+
+### 6. Add a note
+
+To add a note, open the more-options (**⋮**) menu of the row. Select **Add notes**. Type the note.
+
+Select **Show notes** to open the note text. Select **Hide notes** to close the note text.
+
+### 7. Add the other diagnoses
+
+Repeat from step 2 for each further diagnosis.
+
+If you select a term that the encounter already has, Care shows the warning "Diagnosis already exists!". Care does not add a second row.
+
+### 8. Submit the diagnoses
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- The diagnoses appear in the **Diagnoses** section of the encounter **Overview** tab.
+- The diagnoses appear in the **Past Diagnoses** clinical history of the patient.
+
+When the encounter has no diagnosis, the section shows "No Diagnoses" with the message "No Diagnoses have been recorded".
+
+## Related
+
+Concepts:
+
+- [Condition](../../../concepts/clinical/condition.mdx)
+
+Flows:
+
+- [Record a symptom](./record-symptom.mdx)
+- [Add a symptom or diagnosis from past records](./add-condition-from-past-records.mdx)
+- [Update a symptom or diagnosis](./update-condition.mdx)
+- [Mark a symptom or diagnosis as entered in error](./condition-entered-in-error.mdx)
+- [View the clinical history](./view-clinical-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/condition/record-symptom.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/condition/record-symptom.mdx
@@ -1,0 +1,122 @@
+---
+sidebar_position: 1
+---
+
+# Record a symptom
+
+## Overview
+
+This flow describes how to record a symptom for a patient during an encounter. Care stores each symptom as a [condition](../../../concepts/clinical/condition.mdx).
+
+## Pre-requisites
+
+- The patient has an open encounter at the facility, and that encounter is the patient's active encounter.
+- The encounter is not Completed, Cancelled, Discontinued, or Entered in Error. In these states, all add and edit controls are read-only.
+- You have the permissions listed below.
+
+Note: Without an active encounter, the screen shows "Symptoms cannot be recorded without an active encounter".
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | Lets you see the symptoms of the patient. |
+| Can Read encounter related clinical data | Lets you see the symptoms of the encounter. |
+| Update Encounter related clinical data | Lets you record and change symptoms. |
+
+Doctors, nurses, administrators, and facility administrators have the Update Encounter related clinical data permission by default.
+
+Without view access, the encounter shows "You do not have permission to view clinical data for this encounter".
+
+## Steps
+
+### 1. Open the symptom screen
+
+Open the encounter. Go to the **Overview** tab. Find the **Symptoms** section. Select the edit (pencil) icon.
+
+You can also press the keyboard shortcut **s** on any encounter screen. The shortcut opens the same symptom screen.
+
+The symptom screen shows the symptoms that the encounter already has.
+
+### 2. Start a new symptom
+
+Select **Add Symptom**. For each further symptom, the control reads **Add another Symptom**.
+
+A search box opens.
+
+### 3. Search for the symptom
+
+Type a minimum of 3 characters. The screen shows a message below the search box that tells you the minimum length.
+
+The results come from a standard SNOMED CT clinical-finding terminology.
+
+The search box has two tabs:
+
+- **Search**: the terms that match the text that you type.
+- **Starred**: the terms that you pinned.
+
+To pin a term, select the star icon on a result.
+
+Note: Your administrator sets the clinical terminology for your deployment. Your administrator can also change it.
+
+### 4. Select the term
+
+Select a term. A new row appears with these default values:
+
+| Component | Default |
+| --- | --- |
+| Status | Active |
+| Verification | Confirmed |
+| Severity | Moderate |
+| Onset Date | Today |
+
+If you select a term that the encounter already has, Care shows the warning "Symptom already exists!". Care does not add a second row.
+
+### 5. Change the values
+
+Change the values of the row if you need to.
+
+| Component | Options |
+| --- | --- |
+| Status | Active, Recurrence, Relapse, Inactive, Remission, Resolved |
+| Verification | Unconfirmed, Provisional, Differential, Confirmed, Refuted |
+| Severity | Mild, Moderate, Severe |
+| Onset Date | Any date up to today |
+
+Note: Care does not accept a future onset date. Care does not offer Entered in Error for a new symptom.
+
+### 6. Add a note
+
+To add a note, open the more-options (**⋮**) menu of the row. Select **Add notes**. Type the note.
+
+Select **Show notes** to open the note text. Select **Hide notes** to close the note text.
+
+### 7. Add more symptoms
+
+Repeat from step 2 for each further symptom.
+
+### 8. Submit
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- The symptoms appear in the **Symptoms** section of the encounter **Overview** tab.
+- The symptoms appear in the **Past Symptoms** clinical history of the patient.
+
+When the encounter has no symptom, the section shows "No Symptoms" with the message "No symptoms have been recorded".
+
+## Related
+
+Concepts:
+
+- [Condition](../../../concepts/clinical/condition.mdx)
+
+Flows:
+
+- [Record a diagnosis](./record-diagnosis.mdx)
+- [Add a symptom or diagnosis from past records](./add-condition-from-past-records.mdx)
+- [Update a symptom or diagnosis](./update-condition.mdx)
+- [Mark a symptom or diagnosis as entered in error](./condition-entered-in-error.mdx)
+- [View the clinical history](./view-clinical-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/condition/update-condition.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/condition/update-condition.mdx
@@ -1,0 +1,83 @@
+---
+sidebar_position: 4
+---
+
+# Update a symptom or diagnosis
+
+## Overview
+
+This flow describes how to change a symptom or a diagnosis that you already recorded. Care stores each of them as a [condition](../../../concepts/clinical/condition.mdx). Use this flow when the patient improves, or when a provisional finding becomes confirmed.
+
+## Pre-requisites
+
+- You or a colleague recorded the symptom or the diagnosis on the encounter.
+- The encounter is the patient's active encounter.
+- The encounter status is not Completed, Cancelled, Discontinued, or Entered in Error. In these states you can only read the record.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | View the symptoms and the diagnoses of the patient |
+| Can Read encounter related clinical data | View the symptoms and the diagnoses of the encounter |
+| Update Encounter related clinical data | Change a recorded symptom or diagnosis |
+
+## Steps
+
+### 1. Open the symptom screen or the diagnosis screen
+
+Go to the **Overview** tab of the encounter.
+
+For a symptom, select the edit (pencil) icon in the **Symptoms** section. You can also press the keyboard shortcut **s**.
+
+For a diagnosis, select the edit (pencil) icon in the **Diagnoses** section. You can also press the keyboard shortcut **d**.
+
+The records of the encounter show in a list. Each record shows in its own row.
+
+### 2. Change the values
+
+Change the values that you need. You can change these fields on a saved record:
+
+| Component | What it captures |
+| --- | --- |
+| Status | Active, Recurrence, Relapse, Inactive, Remission, or Resolved. |
+| Verification | Unconfirmed, Provisional, Differential, Confirmed, or Refuted. |
+| Severity | Mild, Moderate, or Severe. |
+| Note | Free text about the record. |
+
+Note: The Verification value Entered in Error shows only if the record already has that value. To retract a record, see [Mark a symptom or diagnosis as entered in error](./condition-entered-in-error.mdx).
+
+Note: For a diagnosis you can leave the Severity field empty. The field then shows "Choose severity".
+
+To add a note, open the more-options (**⋮**) menu of the row. Select **Add notes**. Select **Show notes** to open the note text. Select **Hide notes** to close the note text.
+
+### 3. Know the fields that you cannot change
+
+You cannot change the **Onset Date** of a saved record. The field is unavailable after the first submission.
+
+You cannot change the clinical term of a saved record. To correct a wrong term, mark the record as entered in error. Then record the correct term.
+
+### 4. Submit the changes
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the confirmation "Questionnaire submitted successfully".
+- The updated values show in the **Symptoms** section or the **Diagnoses** section of the encounter **Overview** tab.
+- The updated values show in the clinical history of the patient.
+
+## Related
+
+Concepts:
+
+- [Condition](../../../concepts/clinical/condition.mdx)
+
+Flows:
+
+- [Record a symptom](./record-symptom.mdx)
+- [Record a diagnosis](./record-diagnosis.mdx)
+- [Add a symptom or diagnosis from past records](./add-condition-from-past-records.mdx)
+- [Mark a symptom or diagnosis as entered in error](./condition-entered-in-error.mdx)
+- [View the clinical history](./view-clinical-history.mdx)

--- a/versioned_docs/version-3.1/flows/clinical/condition/view-clinical-history.mdx
+++ b/versioned_docs/version-3.1/flows/clinical/condition/view-clinical-history.mdx
@@ -1,0 +1,78 @@
+---
+sidebar_position: 6
+---
+
+# View the clinical history
+
+## Overview
+
+This flow describes how to review the symptoms and the diagnoses of a patient. Care stores each of them as a [condition](../../../concepts/clinical/condition.mdx). You can review the records of the current encounter, or the records of all past encounters.
+
+## Pre-requisites
+
+- You have the permissions listed below. Without one of them, the encounter shows "You do not have permission to view clinical data for this encounter".
+- You do not need write access. This flow is read-only, and it works for an encounter of any status.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | Lets you view the symptoms and the diagnoses of a patient. |
+| Can Read encounter related clinical data | Lets you view the symptoms and the diagnoses of an encounter. |
+
+By default, doctors, nurses, administrators, and facility administrators can read encounter clinical data. Staff can view patient clinical data.
+
+## Steps
+
+### 1. Review the records of the current encounter
+
+1. Open the encounter.
+2. Go to the **Overview** tab.
+3. Read the **Symptoms** section and the **Diagnoses** section. Both sections show the records of that encounter.
+
+Note: When nothing is recorded, the sections show "No Symptoms" with "No symptoms have been recorded", or "No Diagnoses" with "No Diagnoses have been recorded".
+
+### 2. Open the full patient history
+
+1. Select **See Clinical History** on the encounter. You can also press the keyboard shortcut **h**.
+2. The clinical history page of the patient opens. The title of the page shows the name of the patient.
+
+### 3. Review the past records
+
+1. Select the **Past Symptoms** tab or the **Past Diagnoses** tab.
+2. The records show grouped by year and then by date, newest first.
+3. Read each record. A record shows the clinical term, badges for Status, Verification, and Severity, the onset date, and who reported it.
+4. Select **Show notes** to open the note text. Select **Hide notes** to close the note text.
+5. If the record comes from another encounter, select **Go to Encounter** to open that encounter.
+
+### 4. Read the badges
+
+- Status values: Active, Recurrence, Relapse, Inactive, Remission, Resolved.
+- Verification values: Unconfirmed, Provisional, Differential, Confirmed, Refuted, Entered in Error.
+- Severity values: Mild, Moderate, Severe.
+
+Note: A user retracted a record with the Verification value Entered in Error. Do not use that record for clinical decisions.
+
+### 5. Leave the history page
+
+Select **Back to Encounter** or **Back to Patient**.
+
+## Expected Outcome
+
+- You see the symptoms and the diagnoses of the current encounter in the **Overview** tab.
+- You see the symptoms and the diagnoses of all past encounters in the **Past Symptoms** tab and the **Past Diagnoses** tab.
+- You return to the encounter or to the patient after you finish the review.
+
+## Related
+
+Concepts:
+
+- [Condition](../../../concepts/clinical/condition.mdx)
+
+Flows:
+
+- [Record a symptom](./record-symptom.mdx)
+- [Record a diagnosis](./record-diagnosis.mdx)
+- [Add a symptom or diagnosis from past records](./add-condition-from-past-records.mdx)
+- [Update a symptom or diagnosis](./update-condition.mdx)
+- [Mark a symptom or diagnosis as entered in error](./condition-entered-in-error.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-administration/_category_.json
+++ b/versioned_docs/version-3.1/flows/medications/medication-administration/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Medication Administration",
+  "position": 2,
+  "key": "medications-medication-administration-flows"
+}

--- a/versioned_docs/version-3.1/flows/medications/medication-administration/administer-dose.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-administration/administer-dose.mdx
@@ -1,0 +1,97 @@
+---
+sidebar_position: 1
+---
+
+# Administer a dose
+
+## Overview
+
+This flow describes how to record a dose of a prescribed [medicine](../../../concepts/medications/medication-administration.mdx) that staff gave to a patient during an encounter in Care.
+
+## Pre-requisites
+
+- The patient is registered in Care, and you record the dose for that patient.
+- The medicine is prescribed on the encounter. See [Prescribe a medication](../../../flows/medications/medication-request/prescribe-medication.mdx).
+- The medicine is active. Care does not let you administer a discontinued medicine.
+- The encounter is open. You cannot record a dose when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Update Encounter related clinical data | Lets you record a medicine administration on the encounter. |
+
+## Steps
+
+### 1. Open the Medicine Administration sub-tab
+
+1. Open the encounter.
+2. Select the **Medicines** tab.
+3. Select the **Medicine Administration** sub-tab.
+
+Note: Press `g` then `m` to go to the **Medicines** tab.
+
+Care shows a grid. The **Medicine** column lists the prescribed medicines. Four columns to the
+right show six-hour time slots.
+
+### 2. Find the medicine
+
+Care opens the grid on the **Medications** tab. Select the **Nutrition** tab for nutritional
+products. To narrow the list, enter the name in the **Search Medication** box.
+
+### 3. Open the administration form
+
+In the current time slot column, select **Administer** for the medicine. Care opens the
+**Administer Medicine** dialog.
+
+Note: Care shows **Administer** only in the current time slot. Care also hides it when the
+medicine is discontinued, or when the time slot falls outside the prescribed schedule.
+
+Note: To record doses for more than one medicine at a time, select **Administer Medicine** at
+the top of the sub-tab. Select each medicine that you gave, then submit the panel.
+
+### 4. Check the dosage
+
+Care fills the dose, the route, the site, and the method from the prescription. If the
+prescription has more than one dosage instruction, select the instruction that you gave under
+**Select Dosage Instruction**.
+
+### 5. Set the status
+
+Care sets **Status** to Completed. Change the status if staff did not complete the dose.
+
+### 6. Record the time
+
+Care sets **Start Time** and **End Time** to the current date and time.
+
+To record a dose from an earlier time, select **Yes** for **Is this administration for a past
+time**. Care then lets you set **Start Time** and **End Time**.
+
+Note: Care warns you when the time falls outside the prescribed schedule. Care still saves the
+record.
+
+### 7. Add a note
+
+Enter free text in **Administration Notes** to record more detail. This field is optional.
+
+### 8. Save the administration
+
+Select **Administer Medicine** to save the record.
+
+## Expected Outcome
+
+- Care shows the message "Medicine Administration saved".
+- Care adds the dose to the time slot as a coloured chip with the time of the dose.
+- Care shows the last administered time on the medicine row.
+
+## Related
+
+Concepts:
+
+- [Medicine Administration](../../../concepts/medications/medication-administration.mdx)
+
+Flows:
+
+- [View the medicine administration record](./view-medicine-administration.mdx)
+- [Update an administration record](./update-administration-record.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-administration/update-administration-record.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-administration/update-administration-record.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_position: 3
+---
+
+# Update an administration record
+
+## Overview
+
+This flow describes how to change a recorded [medicine administration](../../../concepts/medications/medication-administration.mdx) in Care. For example, you can mark a dose as Not Done, Stopped, or Entered in Error.
+
+## Pre-requisites
+
+- Staff recorded the dose on the encounter. See [Administer a dose](./administer-dose.mdx).
+- The encounter is open. You cannot change a record when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Update Encounter related clinical data | Lets you change an administration record on the encounter. |
+
+## Steps
+
+### 1. Open the Medicine Administration sub-tab
+
+1. Open the encounter.
+2. Select the **Medicines** tab.
+3. Select the **Medicine Administration** sub-tab.
+
+Note: Press `g` then `m` to go to the **Medicines** tab.
+
+### 2. Open the recorded dose
+
+Find the medicine row and the time slot of the dose. Select the chip that shows the time of the
+dose. Care opens the **Edit Administration** dialog.
+
+Note: To find an older dose, move back through the time slots. See
+[View the medicine administration record](./view-medicine-administration.mdx).
+
+### 3. Change the status
+
+Set **Status** to the state that matches what staff did. Select Entered in Error when staff
+created the record by mistake.
+
+### 4. Change the note
+
+Add or change the free text in **Administration Notes**.
+
+### 5. Save your changes
+
+Select **Update** to save the record.
+
+Note: The form does not let you change the medicine, the dosage, the start time, or the end
+time after you save an administration.
+
+## Expected Outcome
+
+- Care shows the message "Medicine Administration saved".
+- Care shows the new status as the colour of the chip in the time slot.
+
+## Related
+
+Concepts:
+
+- [Medicine Administration](../../../concepts/medications/medication-administration.mdx)
+
+Flows:
+
+- [Administer a dose](./administer-dose.mdx)
+- [View the medicine administration record](./view-medicine-administration.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-administration/view-medicine-administration.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-administration/view-medicine-administration.mdx
@@ -1,0 +1,97 @@
+---
+sidebar_position: 2
+---
+
+# View the medication administration record
+
+## Overview
+
+This flow describes how to read the [medicine administration](../../../concepts/medications/medication-administration.mdx) record of an encounter in Care.
+
+## Pre-requisites
+
+- The patient is registered in Care, and you read the record for that patient.
+- The encounter has at least one prescribed medicine.
+- You have one of the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | Lets you view the medicine administrations of the patient. |
+| Can Read encounter related clinical data | Lets you view the medicine administrations of one encounter. |
+
+## Steps
+
+### 1. Open the Medicine Administration sub-tab
+
+1. Open the encounter.
+2. Select the **Medicines** tab.
+3. Select the **Medicine Administration** sub-tab.
+
+Note: Press `g` then `m` to go to the **Medicines** tab.
+
+### 2. Read the grid
+
+The **Medicine** column lists the medicines. Four columns to the right show six-hour time slots.
+A blue dot marks the current time slot.
+
+Each medicine row shows the dosage, the frequency, and the route. The row also shows one of
+these badges.
+
+| Badge | What it means |
+| --- | --- |
+| Active | The patient takes the medicine now. |
+| Stopped | Staff discontinued the medicine. |
+| PRN | Staff give the medicine as needed. |
+
+Note: When a medicine has more than one prescription, Care shows a count next to the name.
+Select the arrow to expand the row and read each prescription on its own line.
+
+### 3. Read the doses
+
+Care shows each recorded dose as a chip in its time slot. The chip shows the time of the dose.
+The colour of the chip shows the status. When a time slot has more than three doses, Care shows
+"+n More".
+
+Note: Select a chip to open the record. See [Update an administration record](./update-administration-record.mdx).
+
+### 4. Move to other time slots
+
+Select the arrow at the left of the grid to move back four time slots. Select the arrow at the
+right to move forward.
+
+Note: Care stops at the earliest prescription date. The left arrow then shows the message
+"Cannot view slots before the earliest prescription date".
+
+### 5. Search for a medicine
+
+Enter the name in the **Search Medication** box. Care shows only the medicines that match.
+
+### 6. Show discontinued medicines
+
+Care hides discontinued medicines. A message under the grid shows how many Care hides.
+
+Select **Show discontinued** to add them to the grid. Care then shows the message
+"Showing all medications".
+
+### 7. Open the drug chart
+
+Select **View Drug Chart** to open the printable chart for the encounter.
+
+## Expected Outcome
+
+- You see which doses staff gave, at what time, and in what state.
+- You see the last administered time for each medicine.
+
+## Related
+
+Concepts:
+
+- [Medicine Administration](../../../concepts/medications/medication-administration.mdx)
+- [Medication Request](../../../concepts/medications/medication-request.mdx)
+
+Flows:
+
+- [Administer a dose](./administer-dose.mdx)
+- [Update an administration record](./update-administration-record.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-dispense/_category_.json
+++ b/versioned_docs/version-3.1/flows/medications/medication-dispense/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Medication Dispense",
+  "position": 3,
+  "key": "medications-medication-dispense-flows"
+}

--- a/versioned_docs/version-3.1/flows/medications/medication-dispense/dispense-medication.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-dispense/dispense-medication.mdx
@@ -1,0 +1,95 @@
+---
+sidebar_position: 1
+---
+
+# Dispense a medication
+
+## Overview
+
+This flow describes how to [dispense](../../../concepts/medications/medication-dispense.mdx) a medicine or a supply item to a patient from the facility's stock in Care.
+
+## Pre-requisites
+
+- The patient has an encounter at the facility.
+- You belong to the location that holds the stock.
+- The item you want to dispense is in stock at that location.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Write Medication Dispense | Lets you dispense a medicine or supply item. Held by Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist. |
+
+## Steps
+
+### 1. Open the Dispense History sub-tab
+
+1. Open the encounter.
+2. Select the **Medicines** tab.
+3. Select the **Dispense History** sub-tab.
+
+Note: Press `g` then `m` to go to the **Medicines** tab.
+
+### 2. Select Dispense
+
+Select **Dispense**. Care opens the location selector.
+
+### 3. Select the location to dispense from
+
+The location selector lists the locations you belong to. Search for a location by name. Select a location to open the locations under it.
+
+Select the location that holds the stock. Care opens the dispense screen.
+
+The dispense screen shows the location under **Selected Location**. To change the location, select **Selected Location**.
+
+Note: If you already added items, Care asks **Change Location?**. Select **Discard & Switch** to change the location and remove the items. Select **Stay here** to keep the items.
+
+### 4. Add the items
+
+1. Select **Add Item**.
+2. Search for the product and select it. Care adds a row for the item.
+3. Care selects the first lot that is not expired. To change the lot, select **Select Lot**. You can select more than one lot for the same item.
+4. Enter the **Quantity** for each lot you selected.
+
+Select **Add Item** again for each other item you want to dispense.
+
+Care shows these columns for each item:
+
+| Column | What it shows |
+| --- | --- |
+| Items | The name of the product. |
+| Select Lot | The lots of that product at the location. |
+| Quantity | The quantity you dispense from each lot. |
+| Base Amount | The base price of the lot. |
+| Expiry | The expiry month and year of the lot. |
+| Actions | The action to remove the item from the list. |
+
+Note: If the location holds no stock of the item, Care shows **No Stock Available**. Remove that item to dispense the other items.
+
+Note: You cannot dispense more than the stock available in a lot.
+
+### 5. Confirm the dispense
+
+Select **Confirm Dispense**. Care shows the message **Items dispensed successfully**.
+
+Note: Press `Shift+Enter` to confirm the dispense.
+
+## Expected Outcome
+
+- Care records a dispense for each lot, and reduces the stock at the location.
+- Care groups the items into one Dispense Order, and sets the order to Completed.
+- Care shows each item in the **Dispense History** sub-tab with the status Completed.
+- Care creates a charge for each item. Care does not create an invoice.
+
+Note: If your deployment turns on automatic invoicing after a dispense, Care opens the invoice screen for the patient's open account.
+
+## Related
+
+Concepts:
+
+- [Medicine Dispense](../../../concepts/medications/medication-dispense.mdx)
+
+Flows:
+
+- [View dispense history](./view-dispense-history.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-dispense/view-dispense-history.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-dispense/view-dispense-history.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 2
+---
+
+# View dispense history
+
+## Overview
+
+This flow describes how to view the [medicine dispense](../../../concepts/medications/medication-dispense.mdx) history for an encounter in Care.
+
+## Pre-requisites
+
+- The patient has an encounter at the facility.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Medication Dispense Read | Lets you view dispense records. Held by Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist. |
+
+## Steps
+
+### 1. Open the Dispense History sub-tab
+
+1. Open the encounter.
+2. Select the **Medicines** tab.
+3. Select the **Dispense History** sub-tab.
+
+Note: Press `g` then `m` to go to the **Medicines** tab.
+
+### 2. Select a Dispense Order
+
+A list on one side shows the Dispense Orders of the patient. Each entry shows the name of the order, or the date and time of the order when the order has no name. Each entry also shows the location.
+
+Care selects the first Dispense Order in the list. Select another Dispense Order to see the items of that order.
+
+Note: On a small screen, select **Select Dispense Order** to open the **Dispense Orders** list.
+
+### 3. Read the dispensed items
+
+Care shows the items of the selected Dispense Order in a table with these columns:
+
+| Column | What it shows |
+| --- | --- |
+| Medicine | The name of the medicine or supply item. |
+| Dosage | The dose of the medicine. |
+| Frequency | How often the patient takes the medicine. |
+| Quantity | The quantity that the pharmacy dispensed. |
+| Location | The location that the pharmacy dispensed from. |
+| Status | The status of the dispense. |
+| Bill Time | The date and time when the pharmacy prepared the item. |
+| Actions | The action to open the item in the pharmacy screen. Care shows this action only for an item that is not Completed. |
+
+Note: If the patient has no dispense record, Care shows **No dispense history found**.
+
+## Expected Outcome
+
+- You see the medicines and supply items that the pharmacy dispensed for the encounter.
+
+## Related
+
+Concepts:
+
+- [Medicine Dispense](../../../concepts/medications/medication-dispense.mdx)
+
+Flows:
+
+- [Dispense a medication](./dispense-medication.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-statement/_category_.json
+++ b/versioned_docs/version-3.1/flows/medications/medication-statement/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Medication Statement",
+  "position": 4,
+  "key": "medications-medication-statement-flows"
+}

--- a/versioned_docs/version-3.1/flows/medications/medication-statement/medication-statement-entered-in-error.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-statement/medication-statement-entered-in-error.mdx
@@ -1,0 +1,67 @@
+---
+sidebar_position: 4
+---
+
+# Mark a medication statement as entered in error
+
+## Overview
+
+This flow describes how to retract a [medication statement](../../../concepts/medications/medication-statement.mdx) that staff recorded by mistake.
+
+## Pre-requisites
+
+- The patient has a medication statement in Care.
+- The encounter of the medication statement is open. Care blocks the change when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view questionnaire responses on patient | Lets you open the **Updates** tab of the patient. |
+| Can submit questionnaire about patients | Lets you open a form for the patient and submit it. |
+| Update Encounter related clinical data | Lets you retract a medication statement of the encounter. |
+
+## Steps
+
+### 1. Open the Medication Statement form
+
+Open the patient.
+
+Select the **Updates** tab. Select **Add Patient Updates**.
+
+Enter `Medication Statement` in the **Search Forms** box. Select **Medication Statement** in the results.
+
+### 2. Open the entry
+
+Select the entry of the medicine that staff recorded by mistake.
+
+### 3. Set the status to Entered in Error
+
+Set the **Status** of the entry to **Entered in Error**.
+
+Note: Care offers this status only for an entry that staff saved before.
+
+Note: You can also select the remove icon of the entry. Care asks you to confirm in the **Remove Medication** dialog. Select **Remove**. Care sets the status of the entry to **Entered in Error**.
+
+### 4. Submit the form
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the message "Questionnaire submitted successfully".
+- Care keeps the medication statement with the status **Entered in Error**.
+- Care no longer shows the statement in the **Medication Statements** sub-tab of the **Medicines** tab.
+
+## Related
+
+Concepts:
+
+- [Medication Statement](../../../concepts/medications/medication-statement.mdx)
+
+Flows:
+
+- [Record a medication statement](./record-medication-statement.mdx)
+- [View medication statements for an encounter](./view-medication-statements.mdx)
+- [Update a medication statement](./update-medication-statement.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-statement/record-medication-statement.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-statement/record-medication-statement.mdx
@@ -1,0 +1,91 @@
+---
+sidebar_position: 1
+---
+
+# Record a medication statement
+
+## Overview
+
+This flow describes how to record a [medication statement](../../../concepts/medications/medication-statement.mdx) for a patient in Care.
+
+## Pre-requisites
+
+- The patient is registered in Care, and you record the statement for that patient.
+- The patient has an encounter at your facility. Care records every medication statement against an encounter.
+- The encounter is open. Care blocks the record when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view questionnaire responses on patient | Lets you open the **Updates** tab of the patient. |
+| Can submit questionnaire about patients | Lets you open a form for the patient and submit it. |
+| Update Encounter related clinical data | Lets you record a medication statement against the encounter. |
+
+## Steps
+
+### 1. Open the Updates tab
+
+Open the patient.
+
+Select the **Updates** tab.
+
+### 2. Start a new form
+
+Select **Add Patient Updates**. Care opens the form page for the patient.
+
+### 3. Select the Medication Statement form
+
+Enter `Medication Statement` in the **Search Forms** box.
+
+Select **Medication Statement** in the results.
+
+Note: **Medication Statement** is a patient form. It is not in the **Forms** list of the encounter.
+
+### 4. Select the medicine
+
+Select **Add Medication**.
+
+Search the clinical drug list for the medicine that the patient reports taking.
+
+Select the medicine in the results. Care adds an entry for it.
+
+### 5. Complete the entry
+
+Complete the fields of the entry.
+
+| Components | What it captures |
+| --- | --- |
+| Source | Who reported the medicine: the **Patient**, a **Practitioner**, or a **Related Person**. Care selects **Patient** by default. |
+| Status | The state of the medication statement. Care selects **Active** by default. |
+| Dosage Instructions | How the patient takes the medicine. This field is mandatory. |
+| Medication Taken Between | The start date and the end date of the period. The start date is mandatory. Leave the end date empty when the patient still takes the medicine. |
+| Reason | Why the patient takes the medicine. You can enter up to 100 characters. |
+| Note | More information about the medicine. |
+
+To record another medicine, repeat step 4 and step 5.
+
+### 6. Submit the form
+
+Select **Submit**.
+
+Note: To finish the form later, select **Save as Draft**.
+
+## Expected Outcome
+
+- Care shows the message "Questionnaire submitted successfully".
+- Care opens the **Updates** tab of the patient.
+- Care shows the medication statement in the **Medication Statements** sub-tab of the **Medicines** tab of the encounter.
+
+## Related
+
+Concepts:
+
+- [Medication Statement](../../../concepts/medications/medication-statement.mdx)
+
+Flows:
+
+- [View medication statements for an encounter](./view-medication-statements.mdx)
+- [Update a medication statement](./update-medication-statement.mdx)
+- [Mark a medication statement as entered in error](./medication-statement-entered-in-error.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-statement/update-medication-statement.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-statement/update-medication-statement.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 3
+---
+
+# Update a medication statement
+
+## Overview
+
+This flow describes how to change a [medication statement](../../../concepts/medications/medication-statement.mdx) that you saved in Care.
+
+## Pre-requisites
+
+- The patient has a medication statement in Care.
+- The encounter of the medication statement is open. Care blocks the change when the encounter status is Completed, Cancelled, Discontinued, or Entered in Error.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view questionnaire responses on patient | Lets you open the **Updates** tab of the patient. |
+| Can submit questionnaire about patients | Lets you open a form for the patient and submit it. |
+| Update Encounter related clinical data | Lets you change a medication statement of the encounter. |
+
+## Steps
+
+### 1. Open the Medication Statement form
+
+Open the patient.
+
+Select the **Updates** tab. Select **Add Patient Updates**.
+
+Enter `Medication Statement` in the **Search Forms** box. Select **Medication Statement** in the results.
+
+Care shows the medication statements that staff recorded before as entries in the form.
+
+### 2. Open the entry
+
+Select the entry of the medicine that you want to change.
+
+### 3. Change the values
+
+Change the **Status** of the entry.
+
+Change the **Note** of the entry.
+
+Note: You cannot change the medicine, the source, the dosage instructions, the period, or the reason of a saved entry. Care disables these fields.
+
+Note: Care disables the full entry when its status is **Entered in Error**.
+
+### 4. Submit the form
+
+Select **Submit**.
+
+## Expected Outcome
+
+- Care shows the message "Questionnaire submitted successfully".
+- Care shows the new status and the new note in the **Medication Statements** sub-tab of the **Medicines** tab.
+
+## Related
+
+Concepts:
+
+- [Medication Statement](../../../concepts/medications/medication-statement.mdx)
+
+Flows:
+
+- [Record a medication statement](./record-medication-statement.mdx)
+- [View medication statements for an encounter](./view-medication-statements.mdx)
+- [Mark a medication statement as entered in error](./medication-statement-entered-in-error.mdx)

--- a/versioned_docs/version-3.1/flows/medications/medication-statement/view-medication-statements.mdx
+++ b/versioned_docs/version-3.1/flows/medications/medication-statement/view-medication-statements.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 2
+---
+
+# View medication statements for an encounter
+
+## Overview
+
+This flow describes how to view the [medication statements](../../../concepts/medications/medication-statement.mdx) of a patient from an encounter in Care.
+
+## Pre-requisites
+
+- The patient is registered in Care, and you open the encounter for that patient.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can view clinical data about patients | Lets you read the medication statements of the patient. |
+| Can Read encounter related clinical data | Lets you read the clinical records of the encounter. |
+
+## Steps
+
+### 1. Open the Medicines tab
+
+Open the encounter.
+
+Select the **Medicines** tab.
+
+Note: To open the **Medicines** tab from anywhere in the encounter, press `g` and then press `m`.
+
+### 2. Select the Medication Statements sub-tab
+
+Select the **Medication Statements** sub-tab.
+
+Care shows the count of the statements next to the title of the list.
+
+Note: The list shows every medication statement of the patient. It does not show only the statements of this encounter.
+
+### 3. Read the table
+
+Care shows the medication statements in a table with these columns:
+
+| Column | What it shows |
+| --- | --- |
+| Medication | The name of the medicine. |
+| Dosage | The dosage instructions for the medicine. |
+| Status | The state of the statement, for example **Active** or **Completed**. |
+| Medication Taken Between | The start date and the end date of the period. Care shows **Ongoing** when there is no end date. |
+| Reason | Why the patient takes the medicine. |
+| Notes | A **See Note** button. Select the button to read the note. |
+| Logged by | The user who recorded the statement. |
+
+Note: Care does not show a statement that staff marked as **Entered in Error**.
+
+### 4. Show more statements
+
+Select **Load More** to add the next statements to the list.
+
+## Expected Outcome
+
+- You see the medication statements of the patient.
+- You see the medicine, the dosage instructions, the status, the period, and the reason for each statement.
+
+## Related
+
+Concepts:
+
+- [Medication Statement](../../../concepts/medications/medication-statement.mdx)
+
+Flows:
+
+- [Record a medication statement](./record-medication-statement.mdx)
+- [Update a medication statement](./update-medication-statement.mdx)
+- [Mark a medication statement as entered in error](./medication-statement-entered-in-error.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -53,6 +53,30 @@
                 "flows/clinical/encounter/complete-encounter",
                 "flows/clinical/encounter/restart-encounter"
               ]
+            },
+            {
+              "type": "category",
+              "label": "Allergy Intolerance",
+              "key": "clinical-allergy-intolerance-flows",
+              "items": [
+                "flows/clinical/allergy-intolerance/record-allergy",
+                "flows/clinical/allergy-intolerance/update-allergy",
+                "flows/clinical/allergy-intolerance/allergy-entered-in-error",
+                "flows/clinical/allergy-intolerance/view-allergy-history"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Condition",
+              "key": "clinical-condition-flows",
+              "items": [
+                "flows/clinical/condition/record-symptom",
+                "flows/clinical/condition/record-diagnosis",
+                "flows/clinical/condition/add-condition-from-past-records",
+                "flows/clinical/condition/update-condition",
+                "flows/clinical/condition/condition-entered-in-error",
+                "flows/clinical/condition/view-clinical-history"
+              ]
             }
           ]
         },
@@ -114,6 +138,36 @@
                 "flows/medications/medication-request/view-encounter-medications",
                 "flows/medications/medication-request/update-prescription",
                 "flows/medications/medication-request/print-prescription"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Medication Administration",
+              "key": "medications-medication-administration-flows",
+              "items": [
+                "flows/medications/medication-administration/administer-dose",
+                "flows/medications/medication-administration/view-medicine-administration",
+                "flows/medications/medication-administration/update-administration-record"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Medication Dispense",
+              "key": "medications-medication-dispense-flows",
+              "items": [
+                "flows/medications/medication-dispense/dispense-medication",
+                "flows/medications/medication-dispense/view-dispense-history"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Medication Statement",
+              "key": "medications-medication-statement-flows",
+              "items": [
+                "flows/medications/medication-statement/record-medication-statement",
+                "flows/medications/medication-statement/view-medication-statements",
+                "flows/medications/medication-statement/update-medication-statement",
+                "flows/medications/medication-statement/medication-statement-entered-in-error"
               ]
             }
           ]


### PR DESCRIPTION
## What

Publishes five clinical modules from `care_docs` into the docs site (version 3.1). 19 flows and 5 refreshed concepts.

### Under `Flows > Clinical`

| Module | Flows |
| --- | --- |
| Allergy Intolerance | record, update, mark as entered in error, view history |
| Condition | record a symptom, record a diagnosis, add from past records, update, mark as entered in error, view clinical history |

### Under `Flows > Medications`

| Module | Flows |
| --- | --- |
| Medication Administration | administer a dose, view the record, update a record |
| Medication Dispense | dispense a medication, view dispense history |
| Medication Statement | record, view for an encounter, update, mark as entered in error |

All five concepts are replaced with the authored versions.

## Module naming

The `care_docs` folders are all under `Clinical/`, but four of these modules were retargeted so they land on the pages the site already has rather than creating near-duplicates:

| care_docs folder | Published as |
| --- | --- |
| `Clinical/Allergy` | `concepts/clinical/allergy-intolerance` |
| `Clinical/Medication Statement` | `concepts/medications/medication-statement` |
| `Clinical/Medicine Administration` | `concepts/medications/medication-administration` |
| `Clinical/Medicine Dispense` | `concepts/medications/medication-dispense` |

This matches Medication Request, which already sits under the `medications` domain. Concept titles follow the existing page names, so "Medicine Administration" becomes "Medication Administration".

Flow titles were converted from "How to Record an Allergy" to "Record an allergy", matching the other modules.

## Note for reviewers

All five concepts are **replaced**, not extended. Worth confirming nothing needed is lost from the previous versions.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
