### PR TITLE
Add Billing and Accounting docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/billing/account.mdx
+++ b/versioned_docs/version-3.1/concepts/billing/account.mdx
@@ -4,66 +4,91 @@ sidebar_position: 1
 
 # Account
 
-An **account** is the financial ledger that gathers everything billable done for one patient at one facility into a single running balance. Charges flow into it, invoices are raised from it, and payments are settled against it — it is where the platform answers "what does this patient owe here, and what has been paid?"
+## Definition
 
-## What it represents
+An **[account](https://build.fhir.org/account.html)** in Care groups the charge items, invoices, and payments of one patient at one facility. Every charge item, invoice, and payment belongs to exactly one account. The account shows what the patient owes and what the patient paid. Care allows one active, open account for each patient at each facility at a time.
 
-In Care's FHIR-aligned model, an account maps to the **Account** resource. Think of it as a folder, not a bill: it holds the totals and the context, while the actual line items, invoices, and receipts live elsewhere and point back to it.
+## Key Attributes
 
-- **Whose money** — the patient who incurred the costs and the facility where the account lives
-- **What it covers** — a name, an optional description, and a service period (the time window of transactions it spans)
-- **Where it stands** — a lifecycle status (is the account open and usable?) and a separate billing status (where it sits in the billing process)
-- **The running totals** — gross charges, amounts paid, outstanding balance, and charges still waiting to be billed, all maintained by the platform rather than entered by hand
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the account. This field is required. |
+| Description | More detail about the account. This field is optional. |
+| Status | The current state of the account. This field is required. |
+| Billing Status | The current step of the account in the billing lifecycle. This field is required and starts as Open. |
+| Service Period | The start date and end date of the period that the account covers. Care sets the start to the time of creation. |
+| Primary Encounter | One recent encounter of the patient that the account covers. This field is optional. |
+| Tags | Labels that help you group and find accounts. This field is optional. |
+| Financial Summary | The Amount Due, Total Paid, Billed (Gross), and Total Billable values of the account. |
 
-An account is not an invoice and not a single visit. It is a long-lived container: one patient at one facility normally has a single open account that accumulates charges across many encounters, with invoices drawn from it later. The same patient at a different facility gets a separate account, so two facilities' money never mixes.
+### Service Period
 
-## How it connects
+Care sets the service period start to the time when you create the account. You cannot type the start date or the end date. Care shows both dates as read-only.
 
-The account sits between a patient's clinical activity and the money owed for it:
+### Primary Encounter
 
-- **Patient and facility** — every account belongs to exactly one [patient](../clinical/patient) at one [facility](../facility/facility.mdx).
-- **Charge items** — each billable line item ([charge item](../billing/charge-item.mdx)) is placed on the patient's account, and those items are what actually drive the totals.
-- **Encounters** — charges accumulate across many [encounters](../clinical/encounter.mdx), but an account can optionally be tied to one primary encounter for reporting and insurance paperwork.
-- **Invoices and payments** — [invoices](../billing/invoice.mdx) are raised against an account (or against specific items in it), and [payment reconciliations](../billing/payment-reconciliation.mdx) record what has been settled.
+You can set the primary encounter only when you edit the account. Care shows the recent encounters of the patient. An encounter is the primary encounter of one account only.
 
-In practice, clients rarely create an account by hand. The platform materializes a patient's default account automatically the first time a charge item is added for that patient at a facility.
+### Financial Summary
 
-## Lifecycle
+Care calculates the financial summary from the charge items, invoices, and payments of the account. The values are read-only.
 
-An account moves along two parallel tracks. The **activity status** is the coarse one — it answers "can this account still be used?"
+| Value | What it captures |
+| --- | --- |
+| Amount Due | The amount that the patient still owes on the account. |
+| Total Paid | The amount that the patient paid on the account. |
+| Billed (Gross) | The gross amount that the invoices of the account bill. |
+| Total Billable | The total amount that the account can bill. |
 
-```text
-active → on_hold → inactive
-        (active → entered_in_error if created by mistake)
-```
+### Status
 
-- **active** — open and in use; the default state for a patient's working account
-- **on_hold** — temporarily paused, not accepting new activity for now
-- **inactive** — retired from active use but kept for history
-- **entered_in_error** — created by mistake and should be disregarded
+| Status | Description |
+| --- | --- |
+| Active | The account is in use. You can add charge items, invoices, and payments to it. |
+| Inactive | The account is no longer in use. |
+| On Hold | Work on the account stops for now. |
+| Entered in Error | Someone created the account by mistake. |
 
-The **billing status** is the finer track, following the account from open to settled. It begins at `open` (accruing charges), passes through `carecomplete_notbilled` and `billing` as work wraps up and invoicing starts, and ends in one of several closed states: `closed_completed` (billing finished), `closed_voided`, `closed_baddebt`, or `closed_combined` (merged into another account). A default account starts at `active` / `open`; after discharge it is typically balanced and moved toward a closed billing status while the activity status stays usable until the books are settled.
+#### Billing Status
+
+The account page shows the billing lifecycle as a stepper: Open, then Care Completed, then Billing, then Closed.
+
+| Billing Status | Description |
+| --- | --- |
+| Open | The account accepts new charges. |
+| Care Completed | The care for the patient ended. The facility did not bill the account yet. |
+| Billing | The facility prepares and sends the bills for the account. |
+| Closed Bad Debt | The facility closed the account because the patient did not pay. |
+| Closed Voided | The facility closed the account and cancelled it. |
+| Closed Completed | The facility closed the account after full payment. |
+| Closed Combined | The facility closed the account and combined it with another account. |
+
+Note: Care has no delete action for an account. To close an account, change the status and the billing status. Care keeps the account.
+
+## Relationships
+
+- The account belongs to one facility and one patient. You cannot change the patient after you create the account.
+- The account links to one encounter as the primary encounter.
+- Charge items, invoices, and payments each belong to one account.
+- If you add a charge item for a patient and select no account, Care uses the active, open account of that patient at that facility. If the patient has no such account, Care creates one.
 
 ## Permissions
 
-Accounts hold financial information, so access is gated by facility-scoped permissions that keep it visible only to authorized staff.
+Care checks these permissions at the facility level.
 
-| Permission | Description | System Roles |
+| Permission | What it allows | Roles |
 | --- | --- | --- |
-| `can_create_account` | Create a new account for a patient at the facility | Facility Admin, Admin |
-| `can_read_account` | View an account, its balances and totals (also gates retrieve, list, and the default-account lookup) | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-| `can_update_account` | Edit an account (name, status, billing status, service period, primary encounter); also gates rebalancing totals and setting or removing tags | Facility Admin, Admin |
-
-Roles are granted to users through their organization and facility memberships, and permissions cascade down the organization tree — a role held higher up applies to the facilities and patients beneath it.
+| Can Create Account | Create an account. | Facility Admin, Admin |
+| Can Update Account | Edit an account, advance the billing status, settle and close the account, rebalance the account, and manage tags. | Facility Admin, Admin |
+| Can Read Account | View and list accounts. | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
 
 ## Related
 
-- Reference: [Account (technical)](../../references/billing/account.mdx)
-- Concept: [Charge item](../billing/charge-item.mdx)
-- Concept: [Invoice](../billing/invoice.mdx)
-- Concept: [Payment reconciliation](../billing/payment-reconciliation.mdx)
-- Concept: [Patient](../clinical/patient)
-
-## FHIR reference
-
-The account aligns with the FHIR [Account](https://www.hl7.org/fhir/account.html) resource, which represents a financial tool for tracking value accrued for a particular purpose. Care follows this shape closely, though some values differ in spelling — for example, status values use underscores rather than the hyphenated FHIR forms.
+- Flow: [Create an account](../../flows/billing/account/create-account.mdx)
+- Flow: [View an account](../../flows/billing/account/view-account.mdx)
+- Flow: [Edit an account](../../flows/billing/account/edit-account.mdx)
+- Flow: [Advance the billing status of an account](../../flows/billing/account/advance-account-billing-status.mdx)
+- Flow: [Settle and close an account](../../flows/billing/account/settle-and-close-account.mdx)
+- Concept: [Charge Item](../../concepts/billing/charge-item.mdx) - the items that the account bills.
+- Concept: [Invoice](../../concepts/billing/invoice.mdx) - the bill for one or more charge items of the account.
+- Concept: [Payment Reconciliation](../../concepts/billing/payment-reconciliation.mdx) - the payments and credit notes against the account or an invoice.

--- a/versioned_docs/version-3.1/concepts/billing/charge-item.mdx
+++ b/versioned_docs/version-3.1/concepts/billing/charge-item.mdx
@@ -4,66 +4,64 @@ sidebar_position: 2
 
 # Charge Item
 
-A **charge item** is a single billable line for one service or product given to a patient — a consultation fee, a lab test, a dispensed medicine, a bed-day. It is the atom of billing in Care: the smallest unit that records *what was charged, how much, and why*, before anything is grouped onto an invoice.
+## Definition
 
-## What it represents
+A **[charge item](https://build.fhir.org/chargeitem.html)** in Care records one billable service or item against a patient's account. A consultation, a procedure, or a dispensed medicine is each a charge item. Charge items are the building blocks that Care bundles into invoices.
 
-In Care's FHIR-aligned model, a charge item maps to the **ChargeItem** resource. Each one ties four things together:
+You do not open charge items on their own. Charge items always appear inside an appointment, a service request, or the Charge Items tab of an account.
 
-- **What** — the service or product, named by a title and an optional billing code
-- **How much** — the quantity and a full price breakdown that resolves to a total
-- **Why** — the activity that produced it, such as a service request, a dispensed medication, an appointment, or a bed stay, and who performed it
-- **Where** — the patient and the account it sits on, and optionally the encounter it relates to
+## Key Attributes
 
-The key idea is that a charge item is *self-contained*: it carries its own pricing rather than looking up a live rate, so the cost is locked at the moment of charging and never drifts when the catalogue changes later. And a charge item is not an invoice. Charges accumulate on an account as care happens; an [invoice](../billing/invoice.mdx) is the separate, later act of selecting some of them and presenting them for payment.
+| Components | What it captures |
+| --- | --- |
+| Title | The name of the charge. You must enter a title. |
+| Description | More detail about the charge. This is optional. |
+| Quantity | How many units of the service or item the patient receives. You must enter a quantity. |
+| Price Components | The base price and any surcharge, discount, tax, or informational amount. You must enter at least one price component. |
+| Note | A free-text note about the charge. This is optional. |
+| Status | The current state of the charge item. See [Status](#status). |
+| Charge Item Definition | The pre-configured and priced item or service that the charge item comes from, if any. |
+| Performer | The person who performed the billed service. This is optional. |
+| Source record | The clinical record that the charge comes from, where relevant. This is a service request, a medication dispense, an appointment, or a bed association. |
 
-## How it connects
+### Account and Encounter
 
-A charge item never floats on its own — it always points back at the records around it:
+Every charge item belongs to exactly one account. A charge item is optionally linked to one encounter.
 
-- **Account** — every charge item lives on exactly one [account](../billing/account.mdx), the running ledger for a patient. Omit the account and it lands on the patient's default one.
-- **Patient** — the person being billed. Charge against an [encounter](../clinical/encounter.mdx) and the patient is inherited from it automatically.
-- **Encounter** — the visit or admission the charge relates to. Optional: charges can also exist outside any single encounter.
-- **Charge item definition** — an optional template. Applying a [charge item definition](../definitions/charge-item-definition.mdx) builds a fully-priced charge item from the facility's catalogue, so staff never re-key prices by hand.
-- **Invoice** — once a charge is billed and settled, it links back to the [invoice](../billing/invoice.mdx) that paid it.
+You can move a charge item from one account to another account while its status is Billable.
 
-## Pricing model
+### Status
 
-Price is never a single number. A charge item holds a list of **monetary components** that stack up to the total: a **base** per-unit price (exactly one, multiplied by quantity), **surcharges** added on top, **discounts** subtracted (optionally capped by a discount rule), and **tax** applied to what remains. A component can also be marked **informational** — shown for reference but excluded from the total.
+| Status | Description |
+| --- | --- |
+| Billable | The charge item is ready for an invoice. This is the starting status. |
+| Not Billable | The charge item does not go on an invoice. |
+| Aborted | Someone stopped the charge item. |
+| Entered in Error | Someone recorded the charge item by mistake. |
+| Billed | Care sets this status when the charge item goes on an invoice. |
+| Paid | Care sets this status when the invoice for the charge item is Balanced. |
 
-Care recomputes this breakdown on the server every time a charge is created or edited; clients never set the total themselves. When a price departs from the catalogue rate, an override reason can be recorded alongside it.
-
-## Lifecycle
-
-A charge item moves through billing states as it is priced, invoiced, and settled:
-
-```text
-billable → billed → paid
-```
-
-- **billable** — priced and ready to be placed on an invoice
-- **billed** — included on an invoice (set by the platform, not by hand)
-- **paid** — settled, with a link to the invoice and the date it cleared (also platform-set)
-
-Off to the side, a charge can instead be cancelled — recorded but never billed (`not_billable`), called off before billing (`aborted`), or withdrawn as a mistake (`entered_in_error`). Cancelling a charge that was sitting on a draft invoice pulls it off and rebalances that invoice; a charge already on a finalised invoice cannot be cancelled at all. The `billed` and `paid` states are never set manually — they only ever reflect what billing has actually done. Cancellation is free for a short window after creation; after that it requires an explicit permission.
+Note: Not Billable, Aborted, and Entered in Error are the reasons that you choose when you cancel a Billable charge item. Care sets Billed and Paid for you as the invoice moves through its lifecycle.
 
 ## Permissions
 
-Access to charge items is governed by facility-scoped permissions.
+Care checks these permissions at the facility level.
 
-| Permission | Description | System Roles |
+| Permission | What it allows | Roles |
 | --- | --- | --- |
-| `can_create_charge_item` | Create a charge item, apply charge item definitions, and move charge items between accounts | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
-| `can_create_negative_charge_item` | Allow charge items priced below zero (reversals/credits) when applying definitions | Facility Admin, Admin |
-| `can_read_charge_item` | View charge items and their pricing | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-| `can_update_charge_item` | Edit an existing charge item | Facility Admin, Admin |
-| `can_cancel_charge_item` | Cancel a charge item after the free-cancel window has elapsed | Facility Admin, Admin |
+| Can Create Charge Item | Add charge items to an account. | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
+| Can Update Charge Item | Edit a charge item and move charge items to another account. | Facility Admin, Admin |
+| Can Read Charge Item | View and list charge items. | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
+| Can Cancel Charge Item | Cancel a charge item. | Facility Admin, Admin |
 
-Roles are granted to users through facility and organization memberships, and permissions cascade down the organization tree — a role held higher up applies to the facilities and patients beneath it.
+Note: Care lets you edit or cancel a charge item only while its status is Billable.
 
 ## Related
 
-- Reference: [Charge Item (technical)](../../references/billing/charge-item.mdx)
-- Concept: [Account](../billing/account.mdx)
-- Concept: [Charge Item Definition](../definitions/charge-item-definition.mdx)
-- Concept: [Invoice](../billing/invoice.mdx)
+- Flow: [Add charge items](../../flows/billing/charge-item/add-charge-items.mdx)
+- Flow: [Edit a charge item](../../flows/billing/charge-item/edit-charge-item.mdx)
+- Flow: [Cancel a charge item](../../flows/billing/charge-item/cancel-charge-item.mdx)
+- Flow: [Move charge items to another account](../../flows/billing/charge-item/move-charge-items.mdx)
+- Concept: [Account](../../concepts/billing/account.mdx) — every charge item belongs to one account
+- Concept: [Invoice](../../concepts/billing/invoice.mdx) — bundles billable charge items for billing
+- Concept: [Payment Reconciliation](../../concepts/billing/payment-reconciliation.mdx) — records the payments that mark charge items as Paid

--- a/versioned_docs/version-3.1/concepts/billing/invoice.mdx
+++ b/versioned_docs/version-3.1/concepts/billing/invoice.mdx
@@ -4,65 +4,71 @@ sidebar_position: 4
 
 # Invoice
 
-An **invoice** is the bill Care produces for a patient: it gathers the charges raised on an account into a single, numbered statement of what is owed. It is the moment billing becomes official — the point where running charges are frozen into a document the patient or payer can be asked to settle.
+## Definition
 
-## What it represents
+An **[invoice](https://build.fhir.org/invoice.html)** in Care groups one or more billable charge items from an account and bills them to the patient or payer. Care uses the invoice to track the amount that is owed and whether the payer has paid it. Every invoice belongs to one account.
 
-In Care's FHIR-aligned model, an invoice maps to the **Invoice** resource. It pulls together three things: the **charge items** being billed (each a service, medication, or product the patient received), the **money** they add up to (net and gross totals, built from base amounts, surcharges, discounts, and taxes), and the **account** it settles. The patient is inherited from that account, never set by hand.
+## Key Attributes
 
-The key distinction is that an invoice is not a payment. It states what is owed; the act of paying it down — and any credit notes against it — lives in [payment reconciliation](../../references/billing/payment-reconciliation.mdx). One account can produce several invoices over time as new charges accumulate, and the invoice's detail view reports what has been paid against each so you can always see the remaining balance.
+| Components | What it captures |
+| --- | --- |
+| Account | The billing account that the invoice bills. This is required. |
+| Charge items | The billable items on the invoice. You choose them from the account. |
+| Title | A short name for the invoice. This is optional. |
+| Payment Terms | The conditions for payment. This is optional. |
+| Note | Extra information about the invoice. This is optional. |
+| Issue Date | The date when you issue the invoice. Care sets this date when the invoice is issued. |
+| Number | The invoice number. The facility's configuration usually generates it. |
+| Status | The stage of the invoice in its lifecycle. |
 
-## How it connects
+### Issue Date
 
-An invoice sits at the meeting point of several billing primitives:
+The issue date cannot be a date in the future.
 
-- **[Account](../../references/billing/account.mdx)** — every invoice settles exactly one account, and takes its patient from there.
-- **[Charge items](../../references/billing/charge-item.mdx)** — the line items. A charge item is each individual billable thing; the invoice is the envelope that totals them up.
-- **[Charge item definitions](../../references/definitions/charge-item-definition.mdx)** — the priced catalogue entries charge items are built from, used when Care generates a refund invoice automatically.
-- **[Payment reconciliation](../../references/billing/payment-reconciliation.mdx)** — the payments and credit notes recorded against the invoice once it is issued.
+### Charge items
 
-## Lifecycle
+While the invoice is in Draft, the line items follow the live charge items. When you issue the invoice, Care keeps a snapshot of the line items at that moment. A later change to a charge item does not change an invoice that is already issued.
 
-An invoice moves through a small set of statuses, and a crucial thing happens partway through. While an invoice is still a `draft` it shows the live charges — edit a charge item and the invoice follows. The instant it is **issued**, Care takes a frozen snapshot of those line items and computes the totals once. From then on the invoice shows that snapshot, not the live charges. This is deliberate: a bill the patient was handed must not silently change if someone later edits an underlying charge.
+A charge item becomes Billed when you attach it to an invoice. It becomes Paid when the invoice reaches Balanced.
 
-```text
-draft → issued → balanced
-  └────────────→ cancelled / entered_in_error
-```
+### Payments and credit notes
 
-- **draft** — being assembled; charges and totals are still live and editable
-- **issued** — finalised and presented to the patient or payer; line items and totals are now snapshotted
-- **balanced** — fully settled, with payments matching what was owed
-- **cancelled** — voided after issue; no longer collectible
-- **entered_in_error** — recorded by mistake and retracted
+You record payments and credit notes through Payment Reconciliation. A payment or a credit note can target one invoice.
 
-`cancelled` and `entered_in_error` are the two terminal void states. Drive these transitions through the billing workflow rather than editing records directly, since each one also adjusts the linked charge items and the account.
+### Status
 
-## Refunds
+| Status | Description |
+| --- | --- |
+| Draft | You are still preparing the invoice. You can change it. |
+| Issued | You sent the invoice to the patient or payer. Care keeps a snapshot of the line items. |
+| Balanced | The payer settled the invoice in full. This status is final. |
+| Cancelled | You cancelled the invoice. This status is final. |
+| Entered in Error | You created the invoice by mistake. This status is final. |
 
-A normal invoice has positive totals. When goods are returned or a charge is reversed, Care creates a separate **refund invoice** with negative totals. These are flagged as refunds, and Care refuses to save a negative-total invoice that is not marked as one — a guardrail that keeps refunds from being mistaken for ordinary bills.
-
-## Locking
-
-An issued invoice can be **locked** to freeze it against any further edits — useful once a bill has been formally closed out or handed to an external system. Locking is a privileged action, separate from everyday read and write access.
+An invoice moves from Draft to Issued, and then to Balanced. From Draft or Issued, you can move the invoice to Cancelled or to Entered in Error. An invoice cannot move backward. For example, an issued invoice cannot return to Draft. An invoice also cannot move from Draft directly to Balanced.
 
 ## Permissions
 
-Access to invoices is governed by facility-scoped permissions:
+Care checks these permissions at the facility level.
 
-| Permission | Description | System Roles |
+| Permission | What it allows | Roles |
 | --- | --- | --- |
-| `can_write_invoice` | Create and update invoices, including attaching or removing charge items and issuing or balancing them. Also gates cancelling an invoice within the free-cancel window. | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
-| `can_read_invoice` | List and retrieve invoices, their line items, totals, and reconciliation history. | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-| `can_destroy_invoice` | Cancel an invoice after the free-cancel window has elapsed. | Facility Admin, Admin |
-| `can_manage_locked_invoice` | Lock and unlock invoices, and retrieve a locked invoice. | Facility Admin, Admin |
+| Can Write Invoice | Create an invoice, edit it, issue it, add or remove items, and mark it as balanced. | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
+| Can Read Invoice | View and list invoices. | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
+| Can Manage Locked Invoice | Lock or unlock an invoice, and view the full detail of a locked invoice. | Facility Admin, Admin |
+| Can Destroy Invoice | Cancel an invoice after the facility's free-cancel window ends. | Facility Admin, Admin |
 
-Roles are granted through a user's facility and organization memberships, and permissions cascade down the organization tree, so access at a parent organization carries to the facilities beneath it.
+Note: By default the free-cancel window ends immediately. Cancellation therefore usually needs the Can Destroy Invoice permission.
 
 ## Related
 
-- Reference: [Invoice (technical)](../../references/billing/invoice.mdx)
-- Reference: [Account](../../references/billing/account.mdx)
-- Reference: [Charge Item](../../references/billing/charge-item.mdx)
-- Reference: [Payment Reconciliation](../../references/billing/payment-reconciliation.mdx)
-- Concept: [Patient](../clinical/patient)
+- Flow: [Create an invoice](../../flows/billing/invoice/create-invoice.mdx)
+- Flow: [View an invoice](../../flows/billing/invoice/view-invoice.mdx)
+- Flow: [Edit an invoice](../../flows/billing/invoice/edit-invoice.mdx)
+- Flow: [Issue an invoice](../../flows/billing/invoice/issue-invoice.mdx)
+- Flow: [Mark an invoice as balanced](../../flows/billing/invoice/mark-invoice-balanced.mdx)
+- Flow: [Cancel an invoice or mark it entered in error](../../flows/billing/invoice/cancel-invoice.mdx)
+- Flow: [Lock or unlock an invoice](../../flows/billing/invoice/lock-or-unlock-invoice.mdx)
+- Concept: [Account](../../concepts/billing/account.mdx)
+- Concept: [Charge Item](../../concepts/billing/charge-item.mdx)
+- Concept: [Payment Reconciliation](../../concepts/billing/payment-reconciliation.mdx)

--- a/versioned_docs/version-3.1/concepts/billing/payment-reconciliation.mdx
+++ b/versioned_docs/version-3.1/concepts/billing/payment-reconciliation.mdx
@@ -4,81 +4,69 @@ sidebar_position: 5
 
 # Payment Reconciliation
 
-A **payment reconciliation** in Care is the record of a single payment made toward a patient's account — how much was paid, how, when, and by whom. It is how money received at the counter, online, or as a deposit becomes a traceable entry against what the patient owes.
+## Definition
 
-## What it represents
+A **[payment reconciliation](https://build.fhir.org/paymentreconciliation.html)** in Care records a payment that a patient or an insurer makes against an account. You can also record a credit note, which returns money to the payer and subtracts the amount from the balance. A payment can target one specific invoice, or stay as a general credit on the account.
 
-In Care's FHIR-aligned model, a payment reconciliation maps to the **PaymentReconciliation** resource. It captures:
+## Key Attributes
 
-- **Who paid and how** — whether the payer is the patient or an insurer, and the payment method (cash, card, cheque, direct deposit, and similar)
-- **What it applies to** — the account being paid against, and optionally the single invoice this payment settles
-- **How much** — the amount tendered, any amount returned as change, and the net amount that lands on the account
-- **Context** — when the payment happened, where it was taken (e.g. a billing counter), and references such as a cheque or authorization number
+| Components | What it captures |
+| --- | --- |
+| Account | The account that the payment belongs to. Every payment needs an account. |
+| Target Invoice | The invoice that the payment settles. Leave it empty to record a general credit on the account. |
+| Payment Method | How the payer pays the money: Cash, Credit Card, Credit Account, Check, Direct Deposit, or Debit Card. |
+| Payment Type | The nature of the payment: Payment or Advance. |
+| Issuer Type | Who pays the money: Patient or Insurer. |
+| Location | The place where you collect the payment. |
+| Amount Paid | The money that the payer gives. For a credit note, this is the Refund Amount. |
+| Amount Received | The cash that you take from the payer. This applies only to cash payments. |
+| Reference Number | The transaction number or receipt number for the payment. |
+| Payment Date | The date of the payment. |
+| Note | Free text about the payment. |
 
-A payment reconciliation is not a bill. The [invoice](../billing/invoice.mdx) states what is owed; the payment reconciliation records what was actually paid. Several payments can be recorded against one account over time, and a payment can also be a refund or credit note rather than money coming in.
+### Required fields
 
-## How money is calculated
+Account, Payment Method, Payment Type, Amount Paid, and Payment Date are always required. Issuer Type is required for every payment except a credit note. Location is required only if your facility's configuration asks for it.
 
-Care does not simply trust a single "amount" field. Each payment carries two figures, and the net is derived from them:
+Note: The Payment Date cannot be in the future.
 
-- **Tendered amount** — what the payer handed over
-- **Returned amount** — what was given back (typically change)
-- **Amount** — the net that posts to the account, always computed as `tendered − returned`
+### Cash payments
 
-This keeps cash handling honest: the returned amount must be smaller than the tendered amount, and the net is calculated server-side rather than taken at face value. A record can also be flagged as a **credit note**, which inverts the meaning — money owed back to the payer rather than money received.
+For a cash payment, enter the Amount Received. The Amount Received must be equal to or more than the Amount Paid. Care does not show the Reference Number field for cash payments.
 
-## Classification
+### Status
 
-Each payment is tagged so it can be reported and audited consistently. The tags answer a few plain questions:
+| Status | Description |
+| --- | --- |
+| Active | The payment counts towards the account balance. |
+| Cancelled | Someone cancelled the payment. It no longer counts towards the balance. |
+| Draft | The payment is not complete. |
+| Entered in Error | Someone recorded the payment by mistake. |
 
-- **Why** — its `type`: a normal `payment`, an `adjustment` (a correction), or an `advance` (paid ahead of charges)
-- **How it arrived** — its `kind`: `deposit`, `periodic_payment`, `online`, or `kiosk`
-- **Who is paying** — its `issuer_type`: the `patient` or an `insurer`
-- **What instrument** — its `method`: cash, credit card, cheque, debit card, direct deposit, and similar, drawn from standard HL7 payment-method codes
-- **Where processing landed** — its `outcome`: `queued`, `complete`, `partial`, or `error`
+## Relationships
 
-## Lifecycle
-
-A payment moves through a small set of states that mirror real-world handling:
-
-```text
-draft → active → cancelled / entered_in_error
-```
-
-- **draft** — being prepared, not yet a final record of money received
-- **active** — a confirmed payment that counts against the account
-- **cancelled** — a once-valid payment that has been voided
-- **entered_in_error** — recorded by mistake; kept for audit but excluded from balances
-
-## How it connects
-
-A payment reconciliation always sits inside the billing picture for one patient:
-
-- It is recorded against an **[account](../billing/account.mdx)** — the running ledger for a patient, which is always required.
-- It may optionally be allocated to one **[invoice](../billing/invoice.mdx)**, settling that specific bill. With no invoice, the payment simply credits the account balance.
-- It is anchored to a **[facility](../facility/facility.mdx)** and may record the location where the payment was taken (e.g. a billing counter).
-
-Because it points at an account and, through that account, at the [patient](../clinical/patient), a payment reconciliation ties financial activity back to the same person whose [encounters](../clinical/encounter.mdx) and orders drove the charges.
+- Every payment belongs to one account.
+- A payment can target one specific invoice. Without a target invoice, the payment stays as a general credit on the account.
+- A credit note subtracts its amount from the balance instead of adding to it.
+- You can move a payment from one account to another account. Both accounts must belong to the same patient.
 
 ## Permissions
 
-Access to payment records is governed by facility-scoped role-based permissions.
+Care checks these permissions at the facility level.
 
-| Permission | Description | System Roles |
+| Permission | What it allows | Roles |
 | --- | --- | --- |
-| `can_write_payment_reconciliation` | Create, update, cancel within the free-cancel window, or reassign payment records to another account | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
-| `can_read_payment_reconciliation` | List and view payment records | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-| `can_destroy_payment_reconciliation` | Cancel a payment record after the free-cancel window has passed | Facility Admin, Admin |
+| Can Write Payment Reconciliation | Record a payment, update a payment, and move a payment to another account. | Facility Admin, Admin, Staff, Doctor, Nurse, Pharmacist |
+| Can Read Payment Reconciliation | View and list payments. | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
+| Can Destroy Payment Reconciliation | Cancel a payment after the facility's free-cancel window ends. | Facility Admin, Admin |
 
-Roles are granted through a user's facility and organization memberships, and permissions cascade down the organization tree, so a role held higher up applies to the facilities beneath it.
+Note: By default the free-cancel window ends immediately. You usually need the Can Destroy Payment Reconciliation permission to cancel a payment.
 
 ## Related
 
-- Reference: [Payment Reconciliation (technical)](../../references/billing/payment-reconciliation.mdx)
-- Concept: [Account](../billing/account.mdx)
-- Concept: [Invoice](../billing/invoice.mdx)
-- Concept: [Charge item](../billing/charge-item.mdx)
-
-## FHIR reference
-
-This concept aligns with the FHIR [PaymentReconciliation](https://build.fhir.org/paymentreconciliation.html) resource, which records the outcome of payment processing against accounts and invoices.
+- Flow: [Record a payment](../../flows/billing/payment-reconciliation/record-payment.mdx)
+- Flow: [View a payment](../../flows/billing/payment-reconciliation/view-payment.mdx)
+- Flow: [Cancel a payment or mark it entered in error](../../flows/billing/payment-reconciliation/cancel-payment.mdx)
+- Flow: [Move a payment to another account](../../flows/billing/payment-reconciliation/move-payment.mdx)
+- Concept: [Account](../../concepts/billing/account.mdx)
+- Concept: [Invoice](../../concepts/billing/invoice.mdx)

--- a/versioned_docs/version-3.1/flows/billing/_category_.json
+++ b/versioned_docs/version-3.1/flows/billing/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Billing",
+  "position": 5,
+  "key": "billing-flows"
+}

--- a/versioned_docs/version-3.1/flows/billing/account/_category_.json
+++ b/versioned_docs/version-3.1/flows/billing/account/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Account",
+  "position": 1,
+  "key": "billing-account-flows"
+}

--- a/versioned_docs/version-3.1/flows/billing/account/advance-account-billing-status.mdx
+++ b/versioned_docs/version-3.1/flows/billing/account/advance-account-billing-status.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 4
+---
+
+# Advance the billing status of an account
+
+## Overview
+
+This flow describes how to move an [account](../../../concepts/billing/account.mdx) forward in the billing cycle. The billing status shows where the account is in the billing cycle. It is separate from the Active or Inactive status of the account.
+
+## Pre-requisites
+
+- Someone created the account, and you advance the billing status of that account.
+- The account is Active.
+- The account is not in a closed billing status.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Update Account | Lets you change the billing status of an account. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the account
+
+Open the Account page for the account that you want to advance.
+
+### 2. Find the Billing Lifecycle Stepper
+
+On the Account page, find the Billing Lifecycle Stepper. The stepper shows the current billing status of the account.
+
+### 3. Move the account to the next billing status
+
+In the Billing Lifecycle Stepper, select the stage that you want to move the account to. The stepper shows these stages in order:
+
+1. Open
+2. Care Completed
+3. Billing
+
+Note: You can move the account forward only. You cannot move the account back to an earlier stage.
+
+Note: To move the account to a closed billing status, use [Settle and close an account](./settle-and-close-account.mdx). The Billing Lifecycle Stepper does not close an account.
+
+## Expected Outcome
+
+- The Billing Lifecycle Stepper shows the new billing status of the account.
+- The Account page shows the new billing status.
+
+## Related
+
+Concepts:
+
+- [Account](../../../concepts/billing/account.mdx)
+
+Flows:
+
+- [View an account](./view-account.mdx)
+- [Edit an account](./edit-account.mdx)
+- [Settle and close an account](./settle-and-close-account.mdx)

--- a/versioned_docs/version-3.1/flows/billing/account/create-account.mdx
+++ b/versioned_docs/version-3.1/flows/billing/account/create-account.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_position: 1
+---
+
+# Create an account
+
+## Overview
+
+This flow describes how to create an [account](../../../concepts/billing/account.mdx) for a patient at a facility. The account collects the charges and payments for that patient at that facility.
+
+## Pre-requisites
+
+- The patient is registered in Care.
+- You are a member of the facility that bills the patient.
+- The patient has no active, open account at the facility. Care blocks a second active, open account for the same patient at the same facility.
+- You have the permissions listed below.
+
+Note: Care creates a default account for you when you add the first [charge item](../../../concepts/billing/charge-item.mdx) for a patient with no active, open account. In that case, you do not need to create the account yourself.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Account | Create an account for a patient at a facility. Facility Admin and Admin hold this permission. |
+
+## Steps
+
+### 1. Open the account list
+
+Start from the patient or from the facility.
+
+- From the patient: open the patient profile. Select the **Accounts** tab.
+- From the facility: open the facility. Select **Billing**. Select **Accounts**.
+
+### 2. Start the new account
+
+Click **Create Account**. Care opens the account form.
+
+### 3. Fill in the account details
+
+Complete the form fields.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the account. This field is mandatory. |
+| Description | More detail about the account. This field is optional. |
+| Status | The state of the account: Active, Inactive, On Hold, or Entered in Error. This field is mandatory. Keep the value Active for a new account. |
+| Billing Status | The billing state of the account: Open, Care Completed, Billing, Closed Bad Debt, Closed Voided, Closed Completed, or Closed Combined. This field is mandatory and starts at Open. Keep the value Open for a new account. |
+
+### 4. Save the account
+
+Save the form. Care creates the account for the patient and the facility.
+
+## Expected Outcome
+
+- Care creates the account and shows it in the account list.
+- Care sets the service period start date to the current time.
+- Care links the account to the patient and the facility that you created it for. You cannot change this link later.
+- You can set the primary encounter afterwards, when you edit the account.
+
+## Related
+
+Concepts:
+
+- [Account](../../../concepts/billing/account.mdx)
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+
+Flows:
+
+- [View an account](./view-account.mdx)
+- [Edit an account](./edit-account.mdx)

--- a/versioned_docs/version-3.1/flows/billing/account/edit-account.mdx
+++ b/versioned_docs/version-3.1/flows/billing/account/edit-account.mdx
@@ -1,0 +1,73 @@
+---
+sidebar_position: 3
+---
+
+# Edit an account
+
+## Overview
+
+This flow describes how to change the details of an [account](../../../concepts/billing/account.mdx) in Care. You can update the name, description, status, billing status, and primary encounter.
+
+## Pre-requisites
+
+- Someone created the account, and you open its account page.
+- If you set a primary encounter, the patient has at least one encounter.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Update Account | Lets you change the details of an account. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the account
+
+Go to the account page for the account that you want to change.
+
+### 2. Start the edit
+
+Click **Edit Account**. Care opens the account details in edit mode.
+
+Note: Press `e` on the account page to start the same action.
+
+### 3. Update the account details
+
+Change the fields that you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the account. This field is mandatory. |
+| Description | More detail about the account. This field is optional. |
+| Status | The state of the account. Select Active, Inactive, On Hold, or Entered in Error. |
+| Billing Status | The billing state of the account. Select Open, Care Completed, Billing, Closed Bad Debt, Closed Voided, Closed Completed, or Closed Combined. |
+| Primary Encounter | The main encounter for the account. Select one of the patient's most recent encounters. This field is optional. |
+
+Note: You can set the primary encounter only when you edit an account. You cannot set it when you create an account.
+
+Note: An encounter can be the primary encounter of one account only.
+
+Note: You cannot change the patient or the facility of an account.
+
+### 4. Save the changes
+
+Click **Save**.
+
+## Expected Outcome
+
+- Care saves the new account details.
+- The account page shows the updated name, description, status, billing status, and primary encounter.
+
+## Related
+
+Concepts:
+
+- [Account](../../../concepts/billing/account.mdx)
+
+Flows:
+
+- [Create an account](./create-account.mdx)
+- [View an account](./view-account.mdx)
+- [Advance the billing status of an account](./advance-account-billing-status.mdx)
+- [Settle and close an account](./settle-and-close-account.mdx)

--- a/versioned_docs/version-3.1/flows/billing/account/settle-and-close-account.mdx
+++ b/versioned_docs/version-3.1/flows/billing/account/settle-and-close-account.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 5
+---
+
+# Settle and close an account
+
+## Overview
+
+This flow describes how to settle an [account](../../../concepts/billing/account.mdx) in Care and close it with a reason.
+
+## Pre-requisites
+
+- Someone created the account, and you open its account page.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Update Account | Lets you settle and close an account. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Start the action
+
+Open the account page.
+
+Click **Settle & Close**.
+
+Note: Press `s` on the account page to start the same action.
+
+### 2. Choose a closing reason
+
+Select one of these reasons:
+
+| Reason | What it means |
+| --- | --- |
+| Closed Bad Debt | You close the account because the balance is not collectable. |
+| Closed Voided | You close the account because it is void. |
+| Closed Completed | You close the account because all billing is complete. |
+| Closed Combined | You close the account because it is combined with another account. |
+
+### 3. Review the warnings
+
+If the account has a negative balance, Care shows a warning before you continue.
+
+If the account still has charge items that wait for billing, Care shows a warning before you continue.
+
+Read each warning.
+
+### 4. Confirm the closure
+
+Confirm the action.
+
+## Expected Outcome
+
+- Care sets the account status to Inactive.
+- Care sets the billing status to the closing reason that you choose.
+
+## Related
+
+Concepts:
+
+- [Account](../../../concepts/billing/account.mdx)
+
+Flows:
+
+- [View an account](./view-account.mdx)
+- [Edit an account](./edit-account.mdx)
+- [Advance the billing status of an account](./advance-account-billing-status.mdx)

--- a/versioned_docs/version-3.1/flows/billing/account/view-account.mdx
+++ b/versioned_docs/version-3.1/flows/billing/account/view-account.mdx
@@ -1,0 +1,105 @@
+---
+sidebar_position: 2
+---
+
+# View an account
+
+## Overview
+
+This flow describes how to open an [account](../../../concepts/billing/account.mdx) in Care. The account page shows the financial summary, the billing progress, and the billing records of the patient.
+
+## Pre-requisites
+
+- Someone created the account for the patient at the facility.
+- You are a member of the facility that holds the account.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Account | Lets you open an account and see its details. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Open the account list
+
+Use one of these entry points:
+
+- Open the patient profile. Select the **Accounts** tab. This tab lists all the accounts of the patient.
+- Open the facility. Select **Billing**. Select **Accounts**.
+
+Note: On the patient profile, you can filter the accounts by status, billing status, created date, and tags.
+
+### 2. Open the account
+
+Click the account that you want to see. Care opens the account page.
+
+### 3. Read the account details
+
+The top of the page shows this information:
+
+| Component | What it shows |
+| --- | --- |
+| Patient name | The patient that owns the account. |
+| Status badge | The current status of the account. |
+| Service period | The start date and the end date of the service period. |
+| Tags | The tags on the account. |
+
+### 4. Read the financial summary
+
+The Financial Summary shows these amounts:
+
+| Component | What it shows |
+| --- | --- |
+| Amount Due | The amount that the patient must still pay. |
+| Total Paid | The amount that the patient paid. |
+| Billed (Gross) | The gross amount that Care billed. |
+| Total Billable | The amount that Care can bill. |
+
+Care calculates these amounts automatically.
+
+Note: If the amounts look out of date, click **Rebalance**. Care recalculates the Financial Summary from the charge items and the payments of the account.
+
+### 5. Read the billing lifecycle stepper
+
+The Billing Lifecycle Stepper shows the progress of the account through these stages:
+
+1. Open
+2. Care Completed
+3. Billing
+4. Closed
+
+### 6. Open a tab
+
+The account page has these tabs:
+
+| Tab | Keyboard shortcut |
+| --- | --- |
+| Invoices | `Shift+1` |
+| Charge Items | `Shift+2` |
+| Payments | `Shift+3` |
+| Reports | `Shift+4` |
+| Bed Charge Items | `Shift+5` |
+
+Click a tab, or press its keyboard shortcut.
+## Expected Outcome
+
+- Care shows the account page with the patient name, the status, the service period, and the tags.
+- Care shows the Financial Summary and the Billing Lifecycle Stepper.
+- You can open the Invoices, Charge Items, Payments, Reports, and Bed Charge Items tabs.
+
+## Related
+
+Concepts:
+
+- [Account](../../../concepts/billing/account.mdx)
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+
+Flows:
+
+- [Create an account](./create-account.mdx)
+- [Edit an account](./edit-account.mdx)
+- [Advance the billing status of an account](./advance-account-billing-status.mdx)

--- a/versioned_docs/version-3.1/flows/billing/charge-item/_category_.json
+++ b/versioned_docs/version-3.1/flows/billing/charge-item/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Charge Item",
+  "position": 2,
+  "key": "billing-charge-item-flows"
+}

--- a/versioned_docs/version-3.1/flows/billing/charge-item/add-charge-items.mdx
+++ b/versioned_docs/version-3.1/flows/billing/charge-item/add-charge-items.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+---
+
+# Add charge items
+
+## Overview
+
+This flow describes how to add one or more [charge items](../../../concepts/billing/charge-item.mdx) for a patient in Care. You add charge items to record the billable products and services that the patient receives.
+
+## Pre-requisites
+
+- You have the permissions listed below.
+- The patient has an active, billable [account](../../../concepts/billing/account.mdx).
+- If the patient has no active, open account, Care creates one for you when you add the first charge item.
+- You start the flow from an appointment page, a service request page, or the Charge Items tab of an account.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Charge Item | Add charge items to a patient's account. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist roles hold this permission. |
+
+## Steps
+
+### 1. Open the Add Charge Items form
+
+Go to the appointment page, the service request page, or the Charge Items tab of the account.
+
+Click **Add Charge Items**.
+
+Note: On an appointment page or the billing tab of an account, press `a` to open the Add Charge Items form.
+
+### 2. Select the charge item definitions
+
+Select one or more charge item definitions. Each charge item definition is a pre-configured product or service with a price.
+
+| Components | What it captures |
+| --- | --- |
+| Charge Item Definition | The pre-configured, priced product or service that the patient receives. |
+| Quantity | The number of units of the product or service. |
+| Performer | The person who performed the billed service. This field is optional. |
+
+### 3. Set the quantity
+
+Set the quantity for each selected charge item definition.
+
+### 4. Select the performer
+
+Select the performer for each charge item. Skip this field if you do not record a performer.
+
+### 5. Submit the form
+
+Submit the form to create the charge items.
+
+Note: Press `i` on the appointment page or the account page to create an [invoice](../../../concepts/billing/invoice.mdx) from the charge items.
+
+## Expected Outcome
+
+- Care creates one charge item for each selected charge item definition.
+- Each new charge item has the status Billable.
+- The charge items show on the Charge Items tab of the account.
+- If the patient had no active, open account, Care creates the account and adds the charge items to it.
+
+## Related
+
+Concepts:
+
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+- [Account](../../../concepts/billing/account.mdx)
+- [Invoice](../../../concepts/billing/invoice.mdx)
+
+Flows:
+
+- [Edit a charge item](./edit-charge-item.mdx)
+- [Cancel a charge item](./cancel-charge-item.mdx)

--- a/versioned_docs/version-3.1/flows/billing/charge-item/cancel-charge-item.mdx
+++ b/versioned_docs/version-3.1/flows/billing/charge-item/cancel-charge-item.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 3
+---
+
+# Cancel a charge item
+
+## Overview
+
+This flow describes how to cancel a [charge item](../../../concepts/billing/charge-item.mdx) in Care. You give a reason for the cancellation when you change the status.
+
+## Pre-requisites
+
+- Someone added the charge item, and its status is Billable.
+- If the charge item is attached to an invoice, that invoice is still a draft. You cannot cancel a charge item that is attached to an issued or balanced invoice. Cancel the [invoice](../../../concepts/billing/invoice.mdx) first.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Cancel Charge Item | Lets you cancel a charge item. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the row menu
+
+Find the charge item in the list. Open the row menu on the charge item's row.
+
+Note: The status options are available only while the charge item's status is Billable.
+
+### 2. Choose a new status
+
+Choose the status that gives the reason for the cancellation. Care shows these reasons:
+
+- Not Billable
+- Aborted
+- Entered in Error
+
+### 3. Confirm the change
+
+Confirm the change. Care applies the new status to the charge item.
+
+## Expected Outcome
+
+- The charge item shows the new status.
+- If the charge item is attached to a draft invoice, Care removes it from that invoice.
+- Care updates the totals of that draft invoice.
+
+## Related
+
+Concepts:
+
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+- [Invoice](../../../concepts/billing/invoice.mdx)
+
+Flows:
+
+- [Add charge items](./add-charge-items.mdx)
+- [Edit a charge item](./edit-charge-item.mdx)

--- a/versioned_docs/version-3.1/flows/billing/charge-item/edit-charge-item.mdx
+++ b/versioned_docs/version-3.1/flows/billing/charge-item/edit-charge-item.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 2
+---
+
+# Edit a charge item
+
+## Overview
+
+This flow describes how to change the details of a [charge item](../../../concepts/billing/charge-item.mdx) in Care. You can edit a charge item only while its status is Billable.
+
+## Pre-requisites
+
+- Someone added the charge item, and you open it from an appointment, a service request, or an account.
+- The status of the charge item is Billable.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Update Charge Item | Lets you change the details of a charge item. Facility Admin and Admin roles have this permission. |
+
+## Steps
+
+### 1. Open the charge item
+
+Go to the Charge Items tab of the appointment, the service request, or the account.
+
+Find the row of the charge item that you want to change.
+
+### 2. Open the row menu
+
+Open the row menu on the charge item's row.
+
+Select **Edit**.
+
+Note: The Edit option shows only while the status of the charge item is Billable.
+
+### 3. Change the details
+
+Change the fields that you want to update.
+
+| Component | What it captures |
+| --- | --- |
+| Title | The name of the charge item. |
+| Quantity | The number of units of the charge item. |
+| Price components | The base price, the surcharges, the discounts, and the taxes of the charge item. |
+| Note | Extra information about the charge item. |
+
+### 4. Save the charge item
+
+Save your changes.
+
+## Expected Outcome
+
+- Care updates the charge item with the new details.
+- The Charge Items tab shows the updated title, quantity, price components, and note.
+
+## Related
+
+Concepts:
+
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+
+Flows:
+
+- [Add charge items](./add-charge-items.mdx)
+- [Cancel a charge item](./cancel-charge-item.mdx)
+- [Move charge items to another account](./move-charge-items.mdx)

--- a/versioned_docs/version-3.1/flows/billing/charge-item/move-charge-items.mdx
+++ b/versioned_docs/version-3.1/flows/billing/charge-item/move-charge-items.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_position: 4
+---
+
+# Move charge items to another account
+
+## Overview
+
+This flow describes how to move one or more [charge items](../../../concepts/billing/charge-item.mdx) from one account to a different account of the same patient. Use this flow when staff add charge items to the wrong account.
+
+## Pre-requisites
+
+- The patient has the account that holds the charge items you want to move.
+- The patient has a second active [account](../../../concepts/billing/account.mdx) that receives the charge items.
+- The charge items you want to move are still Billable.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Update Charge Item | Lets you move charge items to another account of the same patient. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the Charge Items tab of the account
+
+Open the account that holds the charge items. Select the **Charge Items** tab.
+
+### 2. Select the charge items to move
+
+Select one or more charge items in the list. Each selected charge item must have the status Billable.
+
+### 3. Start the account change
+
+Click **Change Account**.
+
+### 4. Select the destination account
+
+Select the account that receives the charge items. The destination account must be another active account of the same patient.
+
+### 5. Confirm the move
+
+Confirm the change. Care moves the selected charge items to the destination account.
+
+## Expected Outcome
+
+- The selected charge items appear in the destination account.
+- The selected charge items no longer appear in the source account.
+- Care updates the totals of the source account and the destination account.
+
+## Related
+
+Concepts:
+
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+- [Account](../../../concepts/billing/account.mdx)
+
+Flows:
+
+- [Add charge items](./add-charge-items.mdx)
+- [Edit a charge item](./edit-charge-item.mdx)
+- [Cancel a charge item](./cancel-charge-item.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/_category_.json
+++ b/versioned_docs/version-3.1/flows/billing/invoice/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Invoice",
+  "position": 3,
+  "key": "billing-invoice-flows"
+}

--- a/versioned_docs/version-3.1/flows/billing/invoice/cancel-invoice.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/cancel-invoice.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 6
+---
+
+# Cancel an invoice or mark it entered in error
+
+## Overview
+
+This flow describes how to cancel an [invoice](../../../concepts/billing/invoice.mdx) in Care, or how to mark it as Entered in Error.
+
+## Pre-requisites
+
+- You open the page of the invoice that you want to cancel.
+- The invoice is not Balanced, Cancelled, or Entered in Error.
+- The invoice has no active payments recorded against it.
+- The invoice has no active credit notes recorded against it.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Invoice | Lets you cancel an invoice, or mark it as Entered in Error, soon after the invoice was created. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist hold this permission. |
+| Can Destroy Invoice | Lets you cancel an invoice, or mark it as Entered in Error, after the facility's free-cancel window has passed. Facility Admin and Admin hold this permission. |
+
+Note: By default, the free-cancel window is effectively immediate. In most cases you need the Can Destroy Invoice permission.
+
+## Steps
+
+### 1. Open the dropdown menu
+
+Open the invoice page. Click the dropdown menu.
+
+Note: The menu does not show these actions when the invoice is Balanced, Cancelled, or Entered in Error.
+
+### 2. Choose a reason
+
+Select **Mark as Cancelled** to cancel the invoice.
+
+Select **Mark as entered in error** when the invoice was raised by mistake.
+
+### 3. Confirm the action
+
+Confirm the action.
+
+Note: Care blocks this action if the invoice has active payments or credit notes. Resolve the payments and the credit notes first.
+
+## Expected Outcome
+
+- Care sets the invoice status to Cancelled or to Entered in Error.
+- Care reverts the [charge items](../../../concepts/billing/charge-item.mdx) on the invoice to Billable.
+- You can add the reverted charge items to a new invoice.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+
+Flows:
+
+- [Issue an invoice](./issue-invoice.mdx)
+- [Mark an invoice as balanced](./mark-invoice-balanced.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/create-invoice.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/create-invoice.mdx
@@ -1,0 +1,73 @@
+---
+sidebar_position: 1
+---
+
+# Create an invoice
+
+## Overview
+
+This flow describes how to create an [invoice](../../../concepts/billing/invoice.mdx) for an account in Care. The new invoice starts in the Draft state.
+
+## Pre-requisites
+
+- You create the invoice for an account of the patient at your facility.
+- The account has Billable charge items, or you add new charge items from Charge Item Definitions on the invoice page.
+- If you start from an appointment, the patient has an appointment at the facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Invoice | Lets you create an invoice. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Start the invoice
+
+Start the invoice from one of these places:
+
+- Open the account and select the **Invoices** tab.
+- Open the appointment page. Care can pre-select the charge items of that appointment.
+- Open the account and select the **Charge Items** tab. Select the Billable items first.
+
+Note: Press `c` on the billing and invoice pages to create an invoice. Press `i` on an appointment page or an account page to create an invoice with the items pre-selected.
+
+### 2. Select the charge items
+
+Select the Billable charge items of the account that you want to include.
+
+You can also add new charge items on this page. Select the charge items from the Charge Item Definitions.
+
+### 3. Add the invoice details
+
+Add the optional details for the invoice.
+
+| Components | What it captures |
+| --- | --- |
+| Payment Terms | The terms of payment for the invoice. |
+| Note | More information about the invoice. |
+| Issue Date | The date of issue for the invoice. |
+
+### 4. Create the invoice
+
+Click **Create Invoice**.
+
+## Expected Outcome
+
+- Care creates the invoice with the charge items that you selected.
+- The invoice is in the Draft state.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Account](../../../concepts/billing/account.mdx)
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+
+Flows:
+
+- [View an invoice](./view-invoice.mdx)
+- [Edit an invoice](./edit-invoice.mdx)
+- [Issue an invoice](./issue-invoice.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/edit-invoice.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/edit-invoice.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+---
+
+# Edit an invoice
+
+## Overview
+
+This flow describes how to change the details and the items of a draft [invoice](../../../concepts/billing/invoice.mdx) in Care.
+
+## Pre-requisites
+
+- Someone created the invoice, and its status is Draft.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Invoice | Lets you change the details and the items of a draft invoice. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Open the invoice
+
+Open the invoice that you want to change. Confirm that the status of the invoice is Draft. You cannot change an invoice after you issue it.
+
+### 2. Edit the invoice details
+
+Change the invoice details on the invoice page.
+
+| Component | What it captures |
+| --- | --- |
+| Issue Date | The date of the invoice. |
+| Payment Terms | The terms of payment for the invoice. |
+| Note | More information about the invoice. |
+
+Save your changes.
+
+### 3. Edit the invoice items
+
+Change the [charge items](../../../concepts/billing/charge-item.mdx) on the invoice page. You can do these actions:
+
+- Add a charge item that belongs to the same account.
+- Create a charge item from a Charge Item Definition, and add it to the invoice.
+- Remove a charge item from the invoice.
+- Change the title, quantity, price, tax, discount, or performer of an item.
+
+Note: Press `o` to open Other Charge Items. This shows the other charge items of the account that you can add.
+Save your changes.
+
+## Expected Outcome
+
+- The invoice shows the new details and the new items.
+- The invoice stays in Draft status, and you can issue it.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Charge Item](../../../concepts/billing/charge-item.mdx)
+
+Flows:
+
+- [Create an invoice](./create-invoice.mdx)
+- [View an invoice](./view-invoice.mdx)
+- [Issue an invoice](./issue-invoice.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/issue-invoice.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/issue-invoice.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 4
+---
+
+# Issue an invoice
+
+## Overview
+
+This flow describes how to issue a draft [invoice](../../../concepts/billing/invoice.mdx) in Care. When you issue an invoice, Care fixes its line items and offers to record a payment.
+
+## Pre-requisites
+
+- The invoice is in Draft status.
+- The invoice has at least one charge item.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Invoice | Lets you issue the invoice. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Open the invoice
+
+Open the invoice page for the draft invoice.
+
+### 2. Issue the invoice
+
+Click **Issue Invoice**.
+
+Note: Press `i` on the invoice page to issue the invoice.
+
+Care changes the invoice status from Draft to Issued. Care sets the issue date to the current time.
+
+### 3. Record a payment
+
+Care asks you to record a payment against the invoice. Record the payment, or close the prompt to record it later.
+
+## Expected Outcome
+
+- The invoice status changes from Draft to Issued.
+- The issue date shows the time when you issued the invoice.
+- Care offers to record a payment against the invoice.
+- The line items on the invoice are frozen. A later edit to a charge item does not change what the invoice shows.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+
+Flows:
+
+- [Edit an invoice](./edit-invoice.mdx)
+- [Mark an invoice as balanced](./mark-invoice-balanced.mdx)
+- [Cancel an invoice or mark it entered in error](./cancel-invoice.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/lock-or-unlock-invoice.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/lock-or-unlock-invoice.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 7
+---
+
+# Lock or unlock an invoice
+
+## Overview
+
+This flow describes how to lock or unlock an [invoice](../../../concepts/billing/invoice.mdx) in Care. A lock prevents further changes to the invoice. A lock also hides the invoice totals from anyone without the Can Manage Locked Invoice permission.
+
+## Pre-requisites
+
+- Someone created the invoice, and you open the page of that invoice.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Locked Invoice | Lets you lock an invoice, unlock an invoice, and view the full detail of a locked invoice. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the invoice page
+
+Open the invoice that you want to lock or unlock.
+
+Note: A locked invoice hides its full detail. To see the full detail, you need the Can Manage Locked Invoice permission.
+
+### 2. Open the dropdown menu
+
+Click the dropdown menu on the invoice page.
+
+### 3. Lock or unlock the invoice
+
+Select **Lock Invoice** to lock the invoice. If the invoice is locked, select **Unlock Invoice** to unlock it.
+
+## Expected Outcome
+
+- Care locks or unlocks the invoice.
+- A locked invoice accepts no more changes.
+- Care hides the totals of a locked invoice from users without the Can Manage Locked Invoice permission.
+- Care keeps a history of who locked or unlocked the invoice, and when.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+
+Flows:
+
+- [View an invoice](./view-invoice.mdx)
+- [Mark an invoice as balanced](./mark-invoice-balanced.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/mark-invoice-balanced.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/mark-invoice-balanced.mdx
@@ -1,0 +1,54 @@
+---
+sidebar_position: 5
+---
+
+# Mark an invoice as balanced
+
+## Overview
+
+This flow describes how to mark an issued [invoice](../../../concepts/billing/invoice.mdx) as balanced in Care. Care checks the payments and credit notes recorded against the invoice, then closes it.
+
+## Pre-requisites
+
+- The invoice is issued. See [Issue an invoice](./issue-invoice.mdx).
+- You record the payments and credit notes for the invoice before you start. See [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx).
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Invoice | Lets you mark an invoice as balanced. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Open the invoice
+
+Open the invoice page for the invoice that you want to close. The action is available only while the invoice is Issued.
+
+### 2. Mark the invoice as balanced
+
+Click **Mark as balanced**.
+
+Note: Press `b` on the invoice page to mark the invoice as balanced.
+
+Note: This action is final. You cannot change the invoice after Care marks it as balanced.
+
+## Expected Outcome
+
+- Care checks the payments and credit notes recorded against the invoice.
+- The invoice status changes to Balanced.
+- The charge items with the status Billed change to Paid.
+- You cannot change the invoice after this point.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+
+Flows:
+
+- [Issue an invoice](./issue-invoice.mdx)
+- [Cancel an invoice or mark it entered in error](./cancel-invoice.mdx)

--- a/versioned_docs/version-3.1/flows/billing/invoice/view-invoice.mdx
+++ b/versioned_docs/version-3.1/flows/billing/invoice/view-invoice.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 2
+---
+
+# View an invoice
+
+## Overview
+
+This flow describes how to open an [invoice](../../../concepts/billing/invoice.mdx) in Care and read its details. You can also print a copy of the invoice.
+
+## Pre-requisites
+
+- Someone created the invoice at your facility.
+- You are a member of the facility that holds the invoice.
+- If the invoice is locked, you have the permission to manage locked invoices. Without it, Care hides the totals of the invoice.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Invoice | Lets you open an invoice and read its details. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission. |
+| Can Manage Locked Invoice | Lets you read the full detail of a locked invoice, with its totals. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the invoice
+
+Use one of these entry points:
+
+- Go to the facility. Select **Billing**. Select **Invoices**. Select the invoice from the list.
+- Open the account. Select the **Invoices** tab. Select the invoice from the list.
+- Scan the QR code of the invoice.
+
+### 2. Read the invoice details
+
+The invoice page shows the following information:
+
+| Section | What it shows |
+| --- | --- |
+| Patient and account summary | The patient and the account of the invoice. |
+| Totals | The total amounts of the invoice. |
+| Line items | The charge items that the invoice includes. |
+| Status | The current status of the invoice. |
+
+Note: If the invoice is locked and you do not have the permission to manage locked invoices, Care hides the totals.
+
+### 3. Print the invoice
+
+Select **Print Invoice**. Care produces a printable copy of the invoice.
+
+Note: The invoice page supports keyboard shortcuts. Press `p` to print the invoice. Press `s` to go to the source. Press `v` to view the invoice.
+
+## Expected Outcome
+
+- You see the patient and account summary, the totals, the line items, and the status of the invoice.
+- You have a printable copy of the invoice when you select **Print Invoice**.
+
+## Related
+
+Concepts:
+
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+
+Flows:
+
+- [Create an invoice](./create-invoice.mdx)
+- [Edit an invoice](./edit-invoice.mdx)
+- [Lock or unlock an invoice](./lock-or-unlock-invoice.mdx)

--- a/versioned_docs/version-3.1/flows/billing/payment-reconciliation/_category_.json
+++ b/versioned_docs/version-3.1/flows/billing/payment-reconciliation/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Payment Reconciliation",
+  "position": 4,
+  "key": "billing-payment-reconciliation-flows"
+}

--- a/versioned_docs/version-3.1/flows/billing/payment-reconciliation/cancel-payment.mdx
+++ b/versioned_docs/version-3.1/flows/billing/payment-reconciliation/cancel-payment.mdx
@@ -1,0 +1,60 @@
+---
+sidebar_position: 3
+---
+
+# Cancel a payment or mark it entered in error
+
+## Overview
+
+This flow describes how to cancel a [payment](../../../concepts/billing/payment-reconciliation.mdx) or mark it entered in error. Care recalculates the account balance after you confirm.
+
+## Pre-requisites
+
+- You recorded the payment in Care, and you open its payment detail page.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Payment Reconciliation | Lets you cancel a payment or mark it entered in error soon after you record it. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+| Can Destroy Payment Reconciliation | Lets you cancel a payment or mark it entered in error after the facility's free-cancel window ends. Facility Admin and Admin have this permission. |
+
+Note: By default, the free-cancel window is effectively immediate. Most users need the Can Destroy Payment Reconciliation permission.
+
+## Steps
+
+### 1. Open the payment detail page
+
+Open the payment that you want to cancel or mark entered in error.
+
+### 2. Choose the reason
+
+Choose one of these actions:
+
+| Action | When to use it |
+| --- | --- |
+| Mark as Cancelled | The payment does not apply anymore. |
+| Mark as entered in error | You recorded the payment by mistake. |
+
+Note: On the payment detail page, press `c` for **Mark as Cancelled**. Press `e` for **Mark as entered in error**.
+
+### 3. Confirm the change
+
+Confirm the reason that you chose.
+
+## Expected Outcome
+
+- The payment shows the status that you chose.
+- Care recalculates the balance of the account.
+
+## Related
+
+Concepts:
+
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+
+Flows:
+
+- [Record a payment](./record-payment.mdx)
+- [View a payment](./view-payment.mdx)

--- a/versioned_docs/version-3.1/flows/billing/payment-reconciliation/move-payment.mdx
+++ b/versioned_docs/version-3.1/flows/billing/payment-reconciliation/move-payment.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 4
+---
+
+# Move a payment to another account
+
+## Overview
+
+This flow describes how to move one or more [payments](../../../concepts/billing/payment-reconciliation.mdx) from one account to a different account of the same patient. Use this flow when you record a payment against the wrong account.
+
+## Pre-requisites
+
+- You recorded the payments for the patient at your facility.
+- The payments are not tied to a specific invoice.
+- The status of each payment is Active or Draft.
+- The patient has another active account that receives the payments.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Payment Reconciliation | Move payments from one account to another account of the same patient. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Start the transfer
+
+Open the account that holds the payments. Open the menu on the account page. Select **Transfer Payment**.
+
+### 2. Select the payments to move
+
+Select one or more payments that you want to move.
+
+Note: You can select only payments that are not tied to a specific invoice. The status of each payment must be Active or Draft.
+
+### 3. Select the destination account
+
+Select the account that receives the payments. The destination account must be an active account of the same patient.
+
+### 4. Confirm the move
+
+Click **Change Account**.
+
+## Expected Outcome
+
+- Care moves the selected payments to the destination account.
+- Care updates the balance of the source account.
+- Care updates the balance of the destination account.
+
+## Related
+
+Concepts:
+
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+- [Account](../../../concepts/billing/account.mdx)
+
+Flows:
+
+- [Record a payment](./record-payment.mdx)
+- [View a payment](./view-payment.mdx)
+- [Cancel a payment or mark it entered in error](./cancel-payment.mdx)

--- a/versioned_docs/version-3.1/flows/billing/payment-reconciliation/record-payment.mdx
+++ b/versioned_docs/version-3.1/flows/billing/payment-reconciliation/record-payment.mdx
@@ -1,0 +1,81 @@
+---
+sidebar_position: 1
+---
+
+# Record a payment
+
+## Overview
+
+This flow describes how to record a [payment reconciliation](../../../concepts/billing/payment-reconciliation.mdx) in Care. You record a payment against an issued [invoice](../../../concepts/billing/invoice.mdx), or as a general credit on an [account](../../../concepts/billing/account.mdx).
+
+## Pre-requisites
+
+- If you record a payment against an invoice, the invoice is issued.
+- If you record a general credit, you open the account page for the patient.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Write Payment Reconciliation | Record a payment or a credit note. Facility Admin, Admin, Staff, Doctor, Nurse, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Start the payment
+
+Start the payment from one of these places:
+
+- On an issued invoice, click **Record Payment**. For a refund invoice, click **Record Credit Note**.
+- After you issue an invoice, Care offers the same action immediately.
+- On an account page, click **Advance/Receipt** to record a payment on the account. To record a credit note, open the menu and select **Record Credit Note**.
+
+Note: Press `r` on an invoice page or an account page to open Record Payment. Press `c` on an account page to open Advance/Receipt.
+
+### 2. Enter the payment details
+
+Complete the form fields.
+
+| Components | What it captures |
+| --- | --- |
+| Payment Method | How the payer pays. Select Cash, Credit Card, Credit Account, Check, Direct Deposit or Debit Card. |
+| Payment Type | The nature of the transaction. Select Payment or Advance. |
+| Issuer Type | Who pays. Select Patient or Insurer. |
+| Location | The place where you collect the payment. |
+| Amount Paid | The amount that the payer pays. |
+| Amount Received | The cash amount that you receive from the payer. |
+| Reference Number | The transaction reference for the payment. |
+| Payment Date | The date of the payment. |
+| Note | More information about the payment. |
+
+For a credit note, Care does not ask for an Issuer Type. Enter the Refund Amount in place of the Amount Paid.
+
+If you select Cash as the Payment Method, enter the Amount Received. Care calculates the change to return.
+
+For all other payment methods, you can enter a Reference Number.
+
+Note: The Payment Date cannot be in the future.
+
+Note: Whether the Location field is mandatory depends on your facility's configuration.
+
+### 3. Submit the payment
+
+Click the submit button to save the payment.
+
+## Expected Outcome
+
+- Care records the payment against the invoice, or as a credit on the account.
+- For a cash payment, Care shows the change to return to the payer.
+
+## Related
+
+Concepts:
+
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+- [Invoice](../../../concepts/billing/invoice.mdx)
+- [Account](../../../concepts/billing/account.mdx)
+
+Flows:
+
+- [View a payment](./view-payment.mdx)
+- [Cancel a payment or mark it entered in error](./cancel-payment.mdx)

--- a/versioned_docs/version-3.1/flows/billing/payment-reconciliation/view-payment.mdx
+++ b/versioned_docs/version-3.1/flows/billing/payment-reconciliation/view-payment.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 2
+---
+
+# View a payment
+
+## Overview
+
+This flow describes how to open a [payment](../../../concepts/billing/payment-reconciliation.mdx) in Care and read its details. You can also print a receipt for the payment.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- Someone recorded the payment at your facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Payment Reconciliation | Lets you open a payment and read its details. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Open the payments list
+
+Go to the facility. Select **Billing**. Select **Payments**. Care shows the list of payments for the facility.
+
+### 2. Open the payment
+
+Click the payment in the list. Care opens the payment detail page.
+
+### 3. Read the payment details
+
+The payment detail page shows these details.
+
+| Component | What it shows |
+| --- | --- |
+| Account | The account that the payment belongs to. |
+| Invoice | The invoice that the payment targets, if the payment targets an invoice. |
+| Amount | The amount of the payment. |
+| Method | The method of the payment. |
+| Type | The type of the payment. |
+| Issuer Type | The type of the party that issues the payment. |
+| Location | The location where the facility takes the payment. |
+| Reference Number | The reference number of the payment. |
+| Payment Date | The date of the payment. |
+| Note | The note for the payment. |
+| Status | The status of the payment. |
+
+### 4. Print the receipt
+
+Select **Print Receipt**. Care creates a printable receipt for the payment.
+
+Note: Press `p` to print the receipt.
+
+### 5. Open the related invoice or account
+
+Click the invoice link to open the related [invoice](../../../concepts/billing/invoice.mdx). Click the account link to open the related account.
+
+Note: Press `v` to view the invoice. Press `a` to view the account.
+
+## Expected Outcome
+
+- Care shows the details of the payment.
+- Care creates a printable receipt when you select **Print Receipt**.
+
+## Related
+
+Concepts:
+
+- [Payment Reconciliation](../../../concepts/billing/payment-reconciliation.mdx)
+- [Invoice](../../../concepts/billing/invoice.mdx)
+
+Flows:
+
+- [Record a payment](./record-payment.mdx)
+- [Cancel a payment or mark it entered in error](./cancel-payment.mdx)
+- [Move a payment to another account](./move-payment.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -260,6 +260,61 @@
         },
         {
           "type": "category",
+          "label": "Billing",
+          "key": "billing-flows",
+          "items": [
+            {
+              "type": "category",
+              "label": "Account",
+              "key": "billing-account-flows",
+              "items": [
+                "flows/billing/account/create-account",
+                "flows/billing/account/view-account",
+                "flows/billing/account/edit-account",
+                "flows/billing/account/advance-account-billing-status",
+                "flows/billing/account/settle-and-close-account"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Charge Item",
+              "key": "billing-charge-item-flows",
+              "items": [
+                "flows/billing/charge-item/add-charge-items",
+                "flows/billing/charge-item/edit-charge-item",
+                "flows/billing/charge-item/cancel-charge-item",
+                "flows/billing/charge-item/move-charge-items"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Invoice",
+              "key": "billing-invoice-flows",
+              "items": [
+                "flows/billing/invoice/create-invoice",
+                "flows/billing/invoice/view-invoice",
+                "flows/billing/invoice/edit-invoice",
+                "flows/billing/invoice/issue-invoice",
+                "flows/billing/invoice/mark-invoice-balanced",
+                "flows/billing/invoice/cancel-invoice",
+                "flows/billing/invoice/lock-or-unlock-invoice"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Payment Reconciliation",
+              "key": "billing-payment-reconciliation-flows",
+              "items": [
+                "flows/billing/payment-reconciliation/record-payment",
+                "flows/billing/payment-reconciliation/view-payment",
+                "flows/billing/payment-reconciliation/cancel-payment",
+                "flows/billing/payment-reconciliation/move-payment"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "category",
           "label": "Scheduling",
           "key": "scheduling-flows",
           "items": [


### PR DESCRIPTION
## What

Publishes the four **Billing and Accounting** modules from `care_docs` into the docs site (version 3.1). 20 flows and 4 refreshed concepts.

| Module | Flows |
| --- | --- |
| Account | create, view, edit, advance the billing status, settle and close |
| Charge Item | add, edit, cancel, move to another account |
| Invoice | create, view, edit, issue, mark as balanced, cancel or mark entered in error, lock or unlock |
| Payment Reconciliation | record, view, cancel or mark entered in error, move to another account |

Adds a `Billing` category to the 3.1 flows sidebar with the four modules nested under it. The concepts replace the existing pages under `concepts/billing/`.

## Frontmatter

None of these files had publishing frontmatter, so `domain`, `module` and `sidebar_position` were added to the four concepts and a `slug` plus `sidebar_position` to all twenty flows. Concept positions follow the existing site order: Account 1, Charge Item 2, Invoice 4, Payment Reconciliation 5.

Flow titles were converted from "How to Create an Invoice" to "Create an invoice", matching the other modules.

## Note for reviewers

All four concepts are **replaced**, not extended. Worth confirming nothing needed is lost from the previous versions.

These modules cross-reference each other heavily — invoice flows link to Account and Charge Item concepts, and so on. Those links are rewritten to the published paths and the build resolves them all.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
