### PR TITLE
Add Supply Delivery and Inventory docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/supply/inventory-item.mdx
+++ b/versioned_docs/version-3.1/concepts/supply/inventory-item.mdx
@@ -1,69 +1,51 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 # Inventory Item
 
-An **inventory item** is the live stock count of one product at one place in your facility — how many units of a specific medicine, consumable, or device are on hand in a particular store, ward, or pharmacy right now. It is the answer to the everyday question "do we have it, and how much?"
+## Definition
 
-## What it represents
+An **[inventory item](https://build.fhir.org/inventoryitem.html)** in Care shows how much of one stocked batch is in stock at one location. Care calculates this count for you. You cannot create or edit an inventory item, and there is no manual stock adjustment.
 
-In Care's FHIR-aligned model, an inventory item maps to the **InventoryItem** resource. Each row captures:
+## Key Attributes
 
-- **What** — the product being counted (a specific medicine, consumable, or supply)
-- **Where** — the single facility location that holds that stock (central store, ward pharmacy, OT cupboard)
-- **How much** — the current on-hand quantity, kept up to date by the system
-- **Availability** — whether the line is live, retired, or recorded in error
+| Components | What it captures |
+| --- | --- |
+| Product | The specific stocked batch that this count is for. |
+| Net Content | The quantity that is in stock now. |
+| Status | The current state of the inventory item. |
+| Expiration Date | The date after which you cannot use the batch. |
+| Batch/Lot Number | The batch or lot number of the stocked product. |
+| Purchase/Base Price | The purchase price or base price of the stocked product. |
 
-An inventory item is not a catalogue entry and not a single transaction. The catalogue says *what a product is*; deliveries and dispenses say *what moved*; the inventory item is the running balance that ties them together. There is exactly one inventory item per product-per-location pair, so "Paracetamol in the ward pharmacy" is always a single, authoritative number.
+### How the count changes
 
-## How quantity is maintained
+Every inventory item belongs to one product and one location. Care changes the count in these situations:
 
-You do not type stock counts into Care by hand. The system creates and updates inventory items for you as supply events happen, so the count always reflects what actually moved rather than what someone remembered to enter.
+- Someone receives a purchase delivery at the location and marks it complete.
+- Someone completes a supply delivery that moves stock to or from the location.
+- Someone dispenses a medicine to a patient from this stock.
 
-- **Deliveries in** raise the count — completed [supply deliveries](../supply/supply-delivery.mdx) arriving at the location add to the balance
-- **Deliveries out** lower the count — stock sent onward to another location is subtracted
-- **Dispenses** lower the count — each [medication dispense](../medications/medication-dispense.mdx) drawn from the line removes units
+### Status
 
-Because the count is recomputed from these source records, it can read negative if more was dispensed or shipped out than the system recorded coming in — a useful signal that a delivery was missed or a count is off, rather than a number to overwrite.
-
-## Lifecycle
-
-```text
-active → inactive
-active → entered_in_error
-```
-
-- **active** — the stock line is live and dispensable; this is the state every newly tracked product starts in
-- **inactive** — no longer actively dispensed, for example when stock is damaged or a product is being phased out at that location
-- **entered_in_error** — the line was created by mistake and should be disregarded
-
-Changing the status is the one thing people do to an inventory item directly; the quantity itself is always system-maintained.
-
-## How it connects
-
-An inventory item sits at the centre of the supply picture, linking the catalogue to real-world movement:
-
-- It points to a [product](../supply/product.mdx), which in turn describes the substance or device through [product knowledge](../definitions/product-knowledge.mdx)
-- It belongs to a [location](../facility/location.mdx) inside a facility — the physical place the stock lives
-- Its balance is driven by [supply deliveries](../supply/supply-delivery.mdx) (replenishment and transfers) and [medication dispenses](../medications/medication-dispense.mdx) (consumption at the bedside)
-
-Because a location or product cannot be deleted while stock rows still reference it, the inventory layer protects the integrity of your supply history.
+| Status | Description |
+| --- | --- |
+| Active | The stock count is current and in use. |
+| Inactive | The stock count is no longer in use. |
+| Entered in Error | Someone recorded the stock count by mistake. |
 
 ## Permissions
 
-Access to inventory items is governed at the facility level by role-based permissions.
+Permissions apply within a facility.
 
-| Permission | Description | System Roles |
+| Permission | Roles | What it allows |
 | --- | --- | --- |
-| `can_read_inventory_item` | View the stock lines and on-hand quantities at a facility location | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-
-Roles are granted through a user's facility and organization memberships, and permissions cascade down the organization tree — so a user with facility access sees the inventory for the locations that fall under it.
+| Can Read Inventory Item | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View the stock levels at a location. |
 
 ## Related
 
-- Reference: [Inventory Item (technical)](../../references/supply/inventory-item.mdx)
-- Concept: [Product](../supply/product.mdx)
-- Concept: [Supply Delivery](../supply/supply-delivery.mdx)
-- Concept: [Medication Dispense](../medications/medication-dispense.mdx)
-- Concept: [Location](../facility/location.mdx)
+- Flow: [View stock levels at a location](../../flows/supply/inventory-item/view-stock-levels.mdx)
+- Concept: [Product](../../concepts/supply/product.mdx) — the catalog and stocked-batch records that an inventory item counts
+- Concept: [Purchase Delivery](../../concepts/supply/purchase-delivery.mdx) — receiving one increases stock
+- Concept: [Supply Delivery](../../concepts/supply/supply-delivery.mdx) — completing one moves stock between locations

--- a/versioned_docs/version-3.1/concepts/supply/product.mdx
+++ b/versioned_docs/version-3.1/concepts/supply/product.mdx
@@ -4,65 +4,89 @@ sidebar_position: 1
 
 # Product
 
-A **product** in Care is a specific batch of a stockable item — a medication, nutritional product, or consumable — as it physically exists at one facility. It is the bridge between your catalogue ("we carry Paracetamol 500mg") and your shelves ("this box, lot A1234, expiring next March").
+## Definition
 
-## What it represents
+Care keeps two kinds of records for every item that a facility stocks or dispenses. A **Product Knowledge** entry is the catalog definition of a type of product, for example "Paracetamol 500mg tablet". A **Product** is one facility's stocked batch of that catalog entry, with its own lot number, expiry date, and purchase price.
 
-In Care's FHIR-aligned model, a product maps loosely to the **Medication** / supply resource family, but Care treats it as the concrete, batch-level instance of a catalogue definition. It captures:
+Note: Care does not map these two records to a single named FHIR R5 resource.
 
-- **Batch detail** — the lot number and expiry date that make one delivery distinct from the next
-- **Pricing & packing** — the purchase price for this batch and the number of units in a standard pack
-- **Catalogue link** — which product definition this batch instantiates
-- **Billing link** — an optional charge definition so the item can be billed when it is used
-- **Status** — whether this batch is in use, retired, or was recorded in error
+## Key Attributes
 
-The key distinction: a product is neither the catalogue entry nor your stock count. The catalogue entry describes *what* an item is in the abstract; a product describes *this particular batch* at a facility; the running quantity on hand is tracked separately by inventory. One catalogue entry can have many products underneath it — one per batch received.
+### Product Knowledge
 
-## How it connects
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the catalog entry. This is required. |
+| Slug | A short unique code that identifies the catalog entry. This is required. |
+| Product Type | The kind of product: Medication, Nutritional Product, or Consumable. This is required. |
+| Category | The group that the catalog entry belongs to. This is required. |
+| Code | A standard medical code for the product. This is optional. |
+| Base Unit | The unit that measures the product, for example tablet or millilitre. This is required. |
+| Status | The stage of the catalog entry. This is required. |
+| Alternate Identifier | Another identifier for the product. This is optional. |
+| Alternate names | Trade names and other aliases of the product. This is optional. |
+| Storage guidelines | The instructions to store the product. This is optional. |
 
-A product sits in the middle of the supply chain, pointing up at the catalogue and down at the stock:
+### Product
 
-- **[Product knowledge](../definitions/product-knowledge.mdx)** — the catalogue definition the product instantiates. Name, codes, dosage form, and product type are read from here, never copied onto the product. A product cannot exist without one.
-- **[Inventory item](../supply/inventory-item.mdx)** — tracks the quantity of a product on hand at a location. The product says *what batch*; the inventory item says *how much, and where*.
-- **[Facility](../facility/facility.mdx)** — every product belongs to exactly one facility, scoped to where it was received rather than shared across your network.
-- **[Charge item definition](../definitions/charge-item-definition.mdx)** — an optional link that raises a charge automatically when the product is billed.
+| Components | What it captures |
+| --- | --- |
+| Status | The stage of the stocked batch. This is required. |
+| Product Knowledge | The catalog entry that the batch belongs to. This is required. You select it when you create the product, and you cannot change it later. |
+| Lot Number | The batch number that the supplier prints on the product. This is optional. |
+| Expiration Date | The date that the batch expires on. This is required. |
+| Standard Pack Size | The number of base units in one pack. This is optional. |
+| Purchase Price | The price that the facility paid for the product. This is optional. |
+| Charge Item Definition | The price that Care uses to bill this product to a patient. This is optional. |
 
-## Types
+## Status
 
-A product's type comes from its catalogue definition, not from the product itself, so you classify an item once and every batch you receive inherits that classification. Care recognises three kinds:
+Product Knowledge and Product use different status values.
 
-- **Medication** — a drug or therapeutic agent
-- **Nutritional product** — feeds, supplements, and similar items
-- **Consumable** — gloves, syringes, dressings, and other single-use supplies
+### Product Knowledge status
 
-## Lifecycle
+| Status | Description |
+| --- | --- |
+| Draft | The catalog entry is not ready for use. |
+| Active | Staff can use the catalog entry. |
+| Retired | The catalog entry is no longer in use. |
 
-```text
-active → inactive
-active → entered_in_error
-```
+### Product status
 
-- **active** — the batch is in use and can be dispensed, consumed, or billed
-- **inactive** — the batch is no longer in use but is retained for history (for example, stock that is fully consumed or expired)
-- **entered_in_error** — the record was created by mistake; it is kept for auditability rather than deleted
+| Status | Description |
+| --- | --- |
+| Active | The facility stocks and dispenses this batch. |
+| Inactive | The facility no longer uses this batch. |
+| Entered in Error | Someone created this batch by mistake. |
 
-Unlike some clinical resources, a product keeps no server-side status history — it simply reflects its current status.
+Note: Care has no delete action for these records. Retire a catalog entry, or set a product to Inactive or Entered in Error.
+
+## Ownership and Sharing
+
+A product always belongs to one catalog entry and one facility. A catalog entry is either global or private. A superuser manages global catalog entries, and all facilities share them. A facility admin manages the private catalog entries of that facility.
+
+## How Products Connect to Stock
+
+An inventory item tracks how much of a product is in stock at one location. Staff most often create a new product while they receive a purchase delivery. When a delivered item is not already in stock, the person who receives the delivery creates the product record for that batch, expiry date, and price.
+
+You can link a product to a charge item definition. Care then creates a billable charge item when staff dispense the product.
 
 ## Permissions
 
-Access to products is granted per facility, so who can see or change a batch depends on the roles a user holds there.
+Permissions apply within a facility.
 
-| Permission | Description | System Roles |
+| Permission | Roles | What it allows |
 | --- | --- | --- |
-| `can_write_product` | Create, update, or upsert products (batches) at a facility | Facility Admin, Admin |
-| `can_read_product` | List and view products at a facility | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-
-Roles are assigned through facility and organization memberships, and permissions cascade down the organization tree — a role granted on a parent organization is inherited by the facilities beneath it. Creating or editing products is limited to administrators, while a broad set of clinical and pharmacy roles can read them.
+| Can Create Product Knowledge on Facility | Facility Admin, Admin | Create and edit catalog entries. |
+| Can Create Product on Facility | Facility Admin, Admin | Create and edit products. |
+| Can Read Product Knowledge | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View catalog entries. |
+| Can Read Product | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View products. |
 
 ## Related
 
-- Reference: [Product (technical)](../../references/supply/product.mdx)
-- Concept: [Product knowledge](../definitions/product-knowledge.mdx)
-- Concept: [Inventory item](../supply/inventory-item.mdx)
-- Concept: [Supply request](../supply/supply-request.mdx)
-- Concept: [Charge item definition](../definitions/charge-item-definition.mdx)
+- Flow: [Add a product to the catalog](../../flows/supply/product/add-product-to-catalog.mdx)
+- Flow: [Edit or retire a catalog entry](../../flows/supply/product/edit-retire-catalog-entry.mdx)
+- Flow: [Add a product instance](../../flows/supply/product/add-product-instance.mdx)
+- Flow: [Edit a product instance](../../flows/supply/product/edit-product-instance.mdx)
+- Concept: [Inventory Item](../../concepts/supply/inventory-item.mdx)
+- Concept: [Purchase Delivery](../../concepts/supply/purchase-delivery.mdx)

--- a/versioned_docs/version-3.1/concepts/supply/purchase-delivery.mdx
+++ b/versioned_docs/version-3.1/concepts/supply/purchase-delivery.mdx
@@ -1,0 +1,75 @@
+---
+sidebar_position: 5
+---
+
+# Purchase Delivery
+
+## Definition
+
+A **purchase delivery** in Care records stock that arrives at your facility from an outside vendor. It bundles one or more [delivered items](https://build.fhir.org/supplydelivery.html) under a single delivery. When you complete the delivery, Care updates the stock levels at the destination location.
+
+Care uses one delivery mechanism for two purposes. A purchase delivery names an external vendor and brings stock into the facility. A supply delivery names an internal source location and moves stock between two locations in the same facility. Both types use the same fields, the same statuses, and the same screens. The vendor or the source location tells you which type you work with.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the delivery. This field is required. |
+| Note | Extra information about the delivery. This field is optional. |
+| Vendor/Distributor | The external supplier organization that sends the goods. This field is required. |
+| Destination | The facility location that receives the goods. This field is required, and it defaults to your current location. |
+| Purchase Order | The purchase order that this delivery fulfills. This link is optional. |
+
+### Purchase Order link
+
+You can link a purchase delivery to the purchase order that it fulfills. Care then fills in the name, the vendor, the destination, and the tags from that purchase order.
+
+### Delivered items
+
+You add delivered items after you create the delivery. Each delivered item records these details:
+
+- The product that arrives
+- The quantity
+- The pack quantity and the pack size
+- The purchase price
+- The tax amount and the discount amount
+- The condition, either Normal or Damaged
+
+If the item is not a known product instance, you can create the product instance while you add the item to the delivery. For more information, see the [Product](../../concepts/supply/product.mdx) concept.
+
+### Status
+
+| Status | Description |
+| --- | --- |
+| Draft | You started the delivery, but it is not ready for receipt. |
+| Pending | The delivery waits for receipt at the destination location. |
+| Completed | The facility received the delivery. Care updates the stock at the destination location. |
+| Abandoned | The delivery stopped before receipt. |
+| Entered in Error | Someone recorded the delivery by mistake. |
+
+## Relationships
+
+- When you complete a purchase delivery, Care creates or updates the inventory item stock count at the destination location.
+- A purchase delivery can reference the purchase order that it fulfills.
+- If a delivery is linked to a patient, the delivery records a medication return. When you complete it, Care creates a refund invoice and reversed charge items on that patient's billing account. If you mark the delivery as Entered in Error, Care reverses the refund invoice and the reversed charge items.
+
+## Permissions
+
+Care controls purchase deliveries with facility-scoped permissions.
+
+| Permission | Roles | What it allows |
+| --- | --- | --- |
+| Can Create External Supply Delivery on Facility | Facility Admin, Admin | Create or edit a purchase delivery and its delivered items. |
+| Can Read Supply Delivery | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View a purchase delivery. |
+
+## Related
+
+- Flow: [Create a purchase delivery](../../flows/supply/purchase-delivery/create-purchase-delivery.mdx)
+- Flow: [Add delivered items to a purchase delivery](../../flows/supply/purchase-delivery/add-items-purchase-delivery.mdx)
+- Flow: [Receive and complete a purchase delivery](../../flows/supply/purchase-delivery/receive-purchase-delivery.mdx)
+- Flow: [View a purchase delivery](../../flows/supply/purchase-delivery/view-purchase-delivery.mdx)
+- Concept: [Supply Delivery](../../concepts/supply/supply-delivery.mdx)
+- Concept: [Purchase Order](../../concepts/supply/purchase-order.mdx)
+- Concept: [Product](../../concepts/supply/product.mdx)
+- Concept: [Inventory Item](../../concepts/supply/inventory-item.mdx)
+- Concept: [Invoice](../../concepts/billing/invoice.mdx)

--- a/versioned_docs/version-3.1/concepts/supply/purchase-order.mdx
+++ b/versioned_docs/version-3.1/concepts/supply/purchase-order.mdx
@@ -1,0 +1,104 @@
+---
+sidebar_position: 3
+---
+
+# Purchase Order
+
+## Definition
+
+A **purchase order** in Care records a request to buy stock from an outside vendor for your facility. It bundles one or more [requested items](https://build.fhir.org/supplyrequest.html) under a single order. Each requested item names a product and a quantity.
+
+Care uses one order mechanism for two purposes. A purchase order names an external vendor and asks that vendor for stock. A supply order names an internal source location and asks another location in the same facility for stock. Both types use the same fields, the same statuses, and the same screens. A purchase order always names an external supplier.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the order. This field is required. |
+| Note | Extra information about the order. This field is optional. |
+| Intent | How firm the order is. This field is required. |
+| Category | The kind of stock that you order. This field is required. |
+| Priority | How urgent the order is. This field is required. |
+| Reason | Why you place the order. This field is required. |
+| Vendor/Distributor | The external supplier organization that you order from. This field is required. |
+| Destination | The facility location that the goods are for. This field is required, and it defaults to your current location. |
+
+### Intent
+
+Intent records how firm the order is. Select one of these values:
+
+- Proposal
+- Plan
+- Directive
+- Order
+- Original Order
+- Reflex Order
+- Filler Order
+- Instance Order
+
+### Category
+
+Category records the kind of stock that you order. Select one of these values:
+
+- Central
+- Nonstock
+
+### Priority
+
+Priority records how urgent the order is. Select one of these values:
+
+- Routine
+- Urgent
+- ASAP
+- STAT
+
+### Reason
+
+Reason records why you place the order. Select one of these values:
+
+- Patient Care
+- Ward Stock
+
+### Requested items
+
+You add requested items after you create the order. Each requested item records these details:
+
+- The product that you request
+- The quantity
+
+### Status
+
+| Status | Description |
+| --- | --- |
+| Draft | You started the order, but it is not ready to send. |
+| Pending | The order waits for the vendor to supply the goods. |
+| Completed | The order is finished. |
+| Abandoned | The order stopped before the vendor supplied the goods. |
+| Entered in Error | Someone recorded the order by mistake. |
+
+## Relationships
+
+- A purchase order does not create a delivery. To record the stock that arrives, create a purchase delivery as a separate step.
+- A purchase delivery can reference the purchase order that it fulfills. Care then fills in the details of the delivery from that order.
+- A requested item names a catalog entry, not a specific stocked batch. For more information, see the [Product](../../concepts/supply/product.mdx) concept.
+
+## Permissions
+
+Care controls purchase orders with facility-scoped permissions.
+
+| Permission | Roles | What it allows |
+| --- | --- | --- |
+| Can Create Supply Request on Facility | Facility Admin, Admin, Staff, Doctor, Nurse | Create or edit a purchase order and its requested items. |
+| Can Read Supply Request | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View a purchase order. |
+
+Note: Care has no separate approve action or complete action for a purchase order. To change the status, edit the order.
+
+## Related
+
+- Flow: [Create a purchase order](../../flows/supply/purchase-order/create-purchase-order.mdx)
+- Flow: [Add items to a purchase order](../../flows/supply/purchase-order/add-items-purchase-order.mdx)
+- Flow: [View a purchase order](../../flows/supply/purchase-order/view-purchase-order.mdx)
+- Flow: [Update the status of a purchase order](../../flows/supply/purchase-order/update-purchase-order-status.mdx)
+- Concept: [Supply Order](../../concepts/supply/supply-request.mdx)
+- Concept: [Purchase Delivery](../../concepts/supply/purchase-delivery.mdx)
+- Concept: [Product](../../concepts/supply/product.mdx)

--- a/versioned_docs/version-3.1/concepts/supply/supply-delivery.mdx
+++ b/versioned_docs/version-3.1/concepts/supply/supply-delivery.mdx
@@ -1,76 +1,58 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Supply Delivery
 
-A **supply delivery** records stock actually moving — a product arriving at a location, whether shipped in from an outside supplier or transferred between rooms inside a facility. It is the "stock in" side of inventory: everything delivered, minus everything dispensed, equals what is on the shelf right now.
+## Definition
 
-## What it represents
+A **[supply delivery](https://build.fhir.org/supplydelivery.html)** in Care records stock that moves from one location to another location in the same facility. For example, the central store dispatches supplies to a ward. One supply delivery groups one or more delivered items under a single delivery. When you complete the delivery, Care moves the stock from the source location count to the destination location count.
 
-In Care's FHIR-aligned model, a supply delivery maps to the **SupplyDelivery** resource. Each delivery is a single line of received goods, capturing:
+Care uses the same delivery mechanism for two purposes. A supply delivery names an internal source location in the same facility. A purchase delivery receives stock from an outside vendor. Both types share the same fields, the same statuses, and the same screens. The source you name decides which type the delivery is.
 
-- **What moved** — the product, or a specific batch already in stock, and how much, counted as whole units or as packs times pack-size
-- **Condition** — whether the items arrived `normal` or `damaged`
-- **Where it came from and went** — carried by the delivery order it belongs to, which names a source and a destination
-- **Why** — an optional link to the supply request this delivery fulfils, and to a billing invoice when stock is handed to a patient
-- **Cost** — the total purchase price of the line
+## Key Attributes
 
-The key distinction is between a request and a delivery. A request is someone *asking* for stock; a delivery is stock *changing hands*. They are not one-to-one: a single request can be met by several deliveries, and a delivery can also happen with no prior request at all — so Care treats the delivery, not the request, as the event that moves inventory.
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the delivery. This is required. |
+| Note | Extra information about the delivery. This is optional. |
+| Deliver From | The facility location that the stock comes from. This is required. |
+| Destination | The facility location that receives the goods. This is required, and defaults to your current location. |
+| Supply Order | The supply order that this delivery fulfills. This is optional. |
 
-## How it connects
+### Supply Order link
 
-A delivery never stands alone — each one belongs to a **delivery order**, the shipment that gives it context. The order answers a single question, *where is this stock coming from and going to*, and its answer shapes everything underneath it:
+You can link a supply delivery to the supply order that it fulfills. Care then pre-fills the name, the source location, the destination, and the tags of the delivery from that order.
 
-- **Origin and destination** — an order always names a destination. If it also names an origin location, it is an internal transfer between two places in the facility. If it has no origin, the stock is entering from outside, and the order names an external **supplier** organization instead.
-- **Internal vs. external** — this one distinction decides what each delivery line must carry. An internal move draws down a specific inventory item, a known batch already on hand; an external delivery names a product being received for the first time. A line is one or the other, never both.
-- **Patient dispense** — an order can instead be aimed at a patient, optionally tied to a billing invoice. An order is either a location-to-location move or a patient dispense, never both — so an order with a patient has no origin.
+### Delivered items
 
-## Lifecycle
+You add delivered items after you create the delivery. Each delivered item names an inventory item and a quantity. The inventory item is a specific batch that is already in stock at the source location. Care checks that the source location holds enough stock before it accepts the item.
 
-A delivery moves through a short lifecycle as goods are received and reconciled:
+### Status
 
-```text
-in_progress → completed
-in_progress → abandoned
-in_progress → entered_in_error
-```
-
-- **in_progress** — the delivery is being recorded but not yet finalized
-- **completed** — goods are received and counted into stock; only completed lines contribute to inventory totals
-- **abandoned** — started but will not be finished
-- **entered_in_error** — created by mistake and should be disregarded
-
-The delivery order that groups these lines has its own status track. Every order begins as `draft` or `pending`, moves to `in_progress`, and settles into one terminal state: `completed`, `abandoned`, or `entered_in_error`.
-
-## Condition
-
-Each line records the state the goods arrived in, so damaged stock is flagged rather than silently counted:
-
-- **normal** — items arrived intact and usable
-- **damaged** — items arrived compromised; the flag supports returns, write-offs, and supplier follow-up
+| Status | Description |
+| --- | --- |
+| Draft | You started the delivery, and you can still change it. |
+| Pending | The delivery waits for the destination location to receive it. |
+| Completed | The destination location received the delivery. Care updated the stock counts. |
+| Abandoned | Nobody continues with the delivery. |
+| Entered in Error | Somebody recorded the delivery by mistake. |
 
 ## Permissions
 
-Access to supply deliveries is governed by facility-scoped permissions.
+Permissions apply for each facility.
 
-| Permission | Description | System Roles |
+| Permission | Roles | What it allows |
 | --- | --- | --- |
-| `can_write_supply_delivery` | Create or update deliveries on internal transfer orders (an order with an origin location); gates both the create and update actions for in-facility moves | Facility Admin, Admin |
-| `can_write_external_supply_delivery` | Create or update deliveries on external orders (no origin, stock arriving from an outside supplier); gates both create and update for inbound deliveries | Facility Admin, Admin |
-| `can_read_supply_delivery` | List and retrieve deliveries and their delivery orders | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-
-Roles are granted to users through their facility and organization memberships, and permissions cascade down the organization tree — so a role held at a parent organization carries to the facilities beneath it.
+| Can Create Supply Delivery on Facility | Facility Admin, Admin | Create or edit a supply delivery and its delivered items. |
+| Can Read Supply Delivery | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View a supply delivery. |
 
 ## Related
 
-- Reference: [Supply Delivery (technical)](../../references/supply/supply-delivery.mdx)
-- Concept: [Supply Request](../supply/supply-request.mdx)
-- Concept: [Inventory Item](../supply/inventory-item.mdx)
-- Concept: [Product](../supply/product.mdx)
-- Concept: [Location](../facility/location.mdx)
-- Concept: [Invoice](../billing/invoice.mdx)
-
-## FHIR reference
-
-This concept aligns with the FHIR **SupplyDelivery** resource, which records the dispatch and receipt of supplies. Care stores coded values (status, condition) as plain snake_case enums rather than FHIR URIs.
+- Flow: [Create a supply delivery](../../flows/supply/supply-delivery/create-supply-delivery.mdx)
+- Flow: [Add delivered items to a supply delivery](../../flows/supply/supply-delivery/add-items-supply-delivery.mdx)
+- Flow: [Receive and complete a supply delivery](../../flows/supply/supply-delivery/receive-supply-delivery.mdx)
+- Flow: [View a supply delivery](../../flows/supply/supply-delivery/view-supply-delivery.mdx)
+- Concept: [Purchase Delivery](../../concepts/supply/purchase-delivery.mdx)
+- Concept: [Supply Order](../../concepts/supply/supply-request.mdx)
+- Concept: [Inventory Item](../../concepts/supply/inventory-item.mdx)

--- a/versioned_docs/version-3.1/concepts/supply/supply-request.mdx
+++ b/versioned_docs/version-3.1/concepts/supply/supply-request.mdx
@@ -2,70 +2,82 @@
 sidebar_position: 4
 ---
 
-# Supply Request
+# Supply Order
 
-A **supply request** is a line item asking for a specific quantity of a catalogue product to be moved into a facility location. It is how a ward, pharmacy, or store says "we need this much of this item here" — the demand signal that drives stock movement across your facility.
+## Definition
 
-## What it represents
+A **[supply order](https://build.fhir.org/supplyrequest.html)** in Care records a request to move stock from one location to another location in the same facility. For example, a ward asks the central store to send more supplies. One supply order bundles one or more requested items, and each requested item names a product and a quantity.
 
-In Care's FHIR-aligned model, a supply request maps to the **SupplyRequest** resource. A single request captures just three things: the catalogue item wanted (a [product knowledge](../definitions/product-knowledge.mdx) entry), the quantity, and where it sits in its workflow.
+Care uses the same order mechanism for two purposes. A supply order requests stock from another location in the same facility. A purchase order requests stock from an outside vendor. The source that you name on the order decides which one you create. A supply order always names an internal source location in the same facility.
 
-The key distinction to hold is that a supply request is not the handover of goods. It expresses demand only; the matching movement of physical stock is recorded separately as a [supply delivery](../supply/supply-delivery.mdx). A request can be raised, fulfilled, or cancelled without anything having physically moved — which is why the request and the delivery are kept as separate records.
+Both types share the same fields, the same statuses, and the same screens.
 
-## How it connects
+## Key Attributes
 
-Supply requests rarely travel alone. Care groups them under a **request order**, which is the unit people actually act on:
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the order. This field is required. |
+| Note | More information about the order. This field is optional. |
+| Intent | How firm the request is. This field is required. |
+| Category | The type of supply. This field is required. |
+| Priority | How urgent the request is. This field is required. |
+| Reason | Why you request the stock. This field is required. |
+| Deliver From | The facility location that you request the stock from. This location must be in the same facility as the destination. This field is required. |
+| Destination | The facility location that needs the stock. Care sets your current location as the default. This field is required. |
 
-- A **request order** describes a movement of items into a **destination** facility location — for example, "restock the ICU pharmacy."
-- One order fans out to **many supply requests**, one per catalogue item being asked for ("50 of these gloves, 20 of that saline").
-- An order can name a **supplier** organization it is sourcing from and an **origin** location it is drawing from, but only the destination is required.
+### Intent
 
-This is the mental model to hold: the **order** answers "where is this going and roughly why," while each **supply request** inside it answers "which item, how much." Because origin and destination are tracked separately, the same physical location can appear as the origin on orders it sends out and the destination on orders it receives.
+Select one of these values: Proposal, Plan, Directive, Order, Original Order, Reflex Order, Filler Order, or Instance Order.
 
-## Order classification
+### Category
 
-A request order carries a few coded attributes that help staff triage and route it — guidance values that shape how an order is read and prioritised, not actions that move stock by themselves:
+Select Central or Nonstock.
 
-| Attribute | Plain meaning | Example values |
-| --- | --- | --- |
-| Priority | How urgently it is needed | `routine`, `urgent`, `asap`, `stat` |
-| Intent | How firm the request is | `proposal`, `plan`, `order` |
-| Reason | Why the stock is needed | `patient_care`, `ward_stock` |
-| Category | Where it is sourced from | `central` (central store), `nonstock` (special order) |
+### Priority
 
-## Lifecycle
+Select Routine, Urgent, ASAP, or STAT.
 
-A supply request moves through its own status as it is worked, from preparation to fulfilment:
+### Reason
 
-```text
-draft → active → processed → completed
-```
+Select Patient Care or Ward Stock.
 
-- **draft** — being prepared, not yet acted on
-- **active** — submitted and open for fulfilment
-- **suspended** — temporarily paused
-- **processed** — picked up and being acted on
-- **completed** — fully fulfilled
-- **cancelled** — withdrawn before fulfilment
-- **entered_in_error** — recorded by mistake and voided
+### Requested items
 
-The parent request order tracks a parallel status of its own — `draft`, `pending`, `in_progress`, `completed`, `abandoned`, or `entered_in_error` — so you can read the state of the whole order independently of any single line item, with the last three treated as closed. Note that status is a workflow label, not an enforced state machine: Care does not block a transition, so the lifecycle reflects how teams agree to work rather than a hard rule.
+You add requested items after you create the order. Each requested item has a product and a quantity. The product is a catalog entry, not a specific stocked batch.
+
+### Status
+
+Care has no separate approve action or complete action. To change the status, edit the order.
+
+| Status | Description |
+| --- | --- |
+| Draft | You started the order, but you did not submit it. |
+| Pending | You submitted the order, and the source location did not fulfill it. |
+| Completed | The source location fulfilled the order. |
+| Abandoned | You stopped the order before fulfillment. |
+| Entered in Error | You recorded the order by mistake. |
+
+## Relationships
+
+- A supply order does not create a delivery. To fulfill the order, create a supply delivery as a separate step.
+- A supply delivery can refer to the supply order that it fulfills. Care then fills in the details of the delivery from that order.
+- A requested item names a catalog entry, not a specific stocked batch. For more information, see the [Product](../../concepts/supply/product.mdx) concept.
 
 ## Permissions
 
-Access to supply requests is controlled by two role-based permissions scoped to a facility.
+Care controls supply orders with facility-scoped permissions.
 
-| Permission | Description | System Roles |
+| Permission | Roles | What it allows |
 | --- | --- | --- |
-| `can_write_supply_request` | Create and update supply requests within a facility | Facility Admin, Admin, Staff, Doctor, Nurse |
-| `can_read_supply_request` | View and list supply requests within a facility | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist |
-
-Roles are granted through a user's membership in a facility or organization, and permissions cascade down the organization tree — so a role held higher up applies to the facilities beneath it.
+| Can Create Supply Request on Facility | Facility Admin, Admin, Staff, Doctor, Nurse | Create or edit a supply order and its requested items. |
+| Can Read Supply Request | Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, Pharmacist | View a supply order. |
 
 ## Related
 
-- Reference: [Supply Request (technical)](../../references/supply/supply-request.mdx)
-- Concept: [Product Knowledge](../definitions/product-knowledge.mdx)
-- Concept: [Supply Delivery](../supply/supply-delivery.mdx)
-- Concept: [Inventory Item](../supply/inventory-item.mdx)
-- Concept: [Location](../facility/location.mdx)
+- Flow: [Raise a supply request](../../flows/supply/supply-request/raise-supply-request.mdx)
+- Flow: [Add items to a supply request](../../flows/supply/supply-request/add-items-supply-request.mdx)
+- Flow: [View a supply request](../../flows/supply/supply-request/view-supply-request.mdx)
+- Flow: [Update the status of a supply request](../../flows/supply/supply-request/update-supply-request-status.mdx)
+- Concept: [Purchase Order](../../concepts/supply/purchase-order.mdx)
+- Concept: [Supply Delivery](../../concepts/supply/supply-delivery.mdx)
+- Concept: [Product](../../concepts/supply/product.mdx)

--- a/versioned_docs/version-3.1/flows/supply/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Supply",
+  "position": 6,
+  "key": "supply-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/inventory-item/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/inventory-item/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Inventory Item",
+  "position": 2,
+  "key": "supply-inventory-item-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/inventory-item/view-stock-levels.mdx
+++ b/versioned_docs/version-3.1/flows/supply/inventory-item/view-stock-levels.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 1
+---
+
+# View stock levels at a location
+
+## Overview
+
+This flow describes how to view the current stock levels of every [inventory item](../../../concepts/supply/inventory-item.mdx) at a storage location in a facility.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- The facility has a storage location that holds stock.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Inventory Item | Lets you view the inventory items and stock levels at a location. |
+
+Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission.
+
+## Steps
+
+### 1. Open the facility services
+
+Go to the facility. Click **Services**.
+
+### 2. Select the storage location
+
+Select the storage location that you want to check.
+
+### 3. Open the inventory
+
+Click **View Inventory**. Care shows every product in stock at the location.
+
+The list shows these details for each product:
+
+| Components | What it shows |
+| --- | --- |
+| Net Content | The quantity of the product in stock. |
+| Status | The status of the inventory item: Active, Inactive, or Entered in Error. |
+| Expiration Date | The date when the product expires. |
+| Batch / Lot Number | The batch or lot number of the product. |
+| Price | The price of the product. |
+
+### 4. Filter the list
+
+Filter the list by catalog entry to see one product only. Filter the list by status to see Active, Inactive, or Entered in Error items.
+
+### 5. Sort the list
+
+Sort the list by quantity. Select low to high, or high to low.
+
+### 6. Open a product
+
+Select a product to see its details.
+
+Note: This page is read-only. You cannot add, remove, or adjust stock here. Stock changes only when you receive a purchase delivery, receive a supply delivery, or dispense medicine to a patient.
+
+## Expected Outcome
+
+- You see the current stock level, status, expiration date, batch or lot number, and price of every product at the location.
+
+## Related
+
+Concepts:
+
+- [Inventory Item](../../../concepts/supply/inventory-item.mdx)
+- [Product](../../../concepts/supply/product.mdx)
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+- [Supply Delivery](../../../concepts/supply/supply-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/product/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/product/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Product",
+  "position": 1,
+  "key": "supply-product-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/product/add-product-instance.mdx
+++ b/versioned_docs/version-3.1/flows/supply/product/add-product-instance.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 3
+---
+
+# Add a product instance
+
+## Overview
+
+This flow describes how to add a [product](../../../concepts/supply/product.mdx) instance in Care. A product instance is one facility's stocked batch of a catalog entry, with its own lot number, expiration date, and purchase price.
+
+## Pre-requisites
+
+- You are a member of the facility that stocks the product.
+- Someone added the catalog entry for the product to the product catalog.
+- If you add the product instance while you receive goods, you record a [purchase delivery](../../../concepts/supply/purchase-delivery.mdx) that contains the delivered item.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Product on Facility | Lets you add a product instance to the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+You can add a product instance from two places. Use the settings screen to manage the facility catalog directly. Use the purchase delivery screen when you receive an item that Care does not know yet. Most new product instances start from a purchase delivery.
+
+### 1. Open the form from facility settings
+
+1. Open the facility.
+2. Select **Settings**.
+3. Select **Products**.
+4. Click **Add Product**.
+
+### 2. Open the form from a purchase delivery
+
+Use this entry point when you add a delivered item that is not a known product instance.
+
+1. Open the purchase delivery.
+2. Add the delivered item.
+3. Create the product instance from the same screen.
+
+### 3. Complete the product details
+
+Enter the details of the batch that the facility stocks.
+
+| Components | What it captures |
+| --- | --- |
+| Product Knowledge | The catalog entry for this product. This field is required. |
+| Status | The availability of the product instance. This field is required, and defaults to Active. |
+| Lot Number | The batch number of the stock. This field is optional. |
+| Expiration Date | The date when the batch expires. This field is required. |
+| Standard Pack Size | The quantity in one standard pack. This field is optional. |
+| Purchase Price | The price that the facility pays for the product. This field is optional. |
+| Charge Item Definition | The charge that bills this product to a patient. This field is optional. |
+
+Note: You select the Product Knowledge entry one time. You cannot change it after you save the product instance.
+
+### 4. Save the product instance
+
+1. Check the details that you entered.
+2. Save the form.
+
+## Expected Outcome
+
+- Care adds the product instance to the facility.
+- The product instance is available when you record a delivered item.
+- If you started from a purchase delivery, the new product instance applies to the delivered item.
+
+## Related
+
+Concepts:
+
+- [Product](../../../concepts/supply/product.mdx)
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+
+Flows:
+
+- [Edit a product instance](./edit-product-instance.mdx)

--- a/versioned_docs/version-3.1/flows/supply/product/add-product-to-catalog.mdx
+++ b/versioned_docs/version-3.1/flows/supply/product/add-product-to-catalog.mdx
@@ -1,0 +1,80 @@
+---
+sidebar_position: 1
+---
+
+# Add a product to the catalog
+
+## Overview
+
+This flow describes how to add a [product](../../../concepts/supply/product.mdx) to the catalog of a facility in Care. A catalog entry defines a product that the facility can stock and use.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- You know the category that the product belongs to.
+- If you add a global entry that applies to all facilities, you are a superuser.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Product Knowledge on Facility | Lets you add a catalog entry for the facility. Facility Admin and Admin have this permission. |
+
+Note: Only a superuser can add a global catalog entry that belongs to no facility.
+
+## Steps
+
+### 1. Open the product knowledge settings
+
+Open the facility.
+
+Click **Settings**.
+
+Click **Product Knowledge**.
+
+### 2. Browse to the category
+
+Browse to the category that the product belongs to.
+
+### 3. Start the new catalog entry
+
+Click **Add Product Knowledge**.
+
+### 4. Complete the form
+
+Complete the form fields.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the product. This field is required. |
+| Slug | A short unique code for the product. This field is required. |
+| Product Type | The type of the product: Medication, Nutritional Product, or Consumable. This field is required. |
+| Category | The category that the product belongs to. This field is required. |
+| Code | A standard code for the product. This field is optional. |
+| Base Unit | The unit that measures the product, for example tablet or millilitre. This field is required. |
+| Status | The status of the product. This field is required, and defaults to Active. |
+| Alternate Identifier | Another identifier for the product. This field is optional. |
+| Alternate names | Other names for the product. This field is optional. |
+| Storage guidelines | The storage instructions for the product. This field is optional. |
+
+### 5. Save the catalog entry
+
+Save the form.
+
+## Expected Outcome
+
+- Care adds the product to the catalog of the facility.
+- The product shows in the selected category.
+- Staff can select the product when they record stock and supply.
+
+## Related
+
+Concepts:
+
+- [Product](../../../concepts/supply/product.mdx)
+
+Flows:
+
+- [Edit or retire a catalog entry](./edit-retire-catalog-entry.mdx)
+- [Add a product instance](./add-product-instance.mdx)

--- a/versioned_docs/version-3.1/flows/supply/product/edit-product-instance.mdx
+++ b/versioned_docs/version-3.1/flows/supply/product/edit-product-instance.mdx
@@ -1,0 +1,75 @@
+---
+sidebar_position: 4
+---
+
+# Edit a product instance
+
+## Overview
+
+This flow describes how to change the details of a [product](../../../concepts/supply/product.mdx) instance at a facility.
+
+## Pre-requisites
+
+- Someone added the product instance at the facility.
+- You are a member of the facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Product on Facility | Lets you add and edit product instances at the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the facility settings
+
+Go to the facility.
+
+Click **Settings**.
+
+### 2. Open the product
+
+Click **Products**.
+
+Click the product that you want to change.
+
+### 3. Start the edit
+
+Click **Edit**.
+
+### 4. Change the details
+
+Change the fields that you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Status | The current state of the product instance. |
+| Lot Number | The manufacturer lot number of the product instance. |
+| Expiration Date | The date after which you cannot use the product instance. |
+| Standard Pack Size | The quantity in one standard pack. |
+| Purchase Price | The price that the facility paid for the product instance. |
+| Charge Item Definition | The charge item definition that Care links to the product instance. |
+
+Note: You cannot change the product knowledge that the product instance is based on.
+
+Note: There is no delete action. To remove a product instance from use, set the Status to **Inactive** or **Entered in Error**.
+
+### 5. Save the changes
+
+Click **Save**.
+
+## Expected Outcome
+
+- Care saves the new details of the product instance.
+- The product page shows the updated details.
+
+## Related
+
+Concepts:
+
+- [Product](../../../concepts/supply/product.mdx)
+
+Flows:
+
+- [Add a product instance](./add-product-instance.mdx)

--- a/versioned_docs/version-3.1/flows/supply/product/edit-retire-catalog-entry.mdx
+++ b/versioned_docs/version-3.1/flows/supply/product/edit-retire-catalog-entry.mdx
@@ -1,0 +1,83 @@
+---
+sidebar_position: 2
+---
+
+# Edit or retire a catalog entry
+
+## Overview
+
+This flow describes how to change the details of a [product](../../../concepts/supply/product.mdx) catalog entry, and how to retire an entry that your facility no longer uses.
+
+## Pre-requisites
+
+- Someone added the catalog entry to the product catalog of your facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Product Knowledge on Facility | Lets you create and edit product catalog entries at the facility. |
+
+Facility Admin and Admin have this permission.
+
+## Steps
+
+### 1. Open the product catalog
+
+1. Go to the facility.
+2. Click **Settings**.
+3. Click **Product Knowledge**.
+
+### 2. Open the catalog entry
+
+1. Find the entry that you want to change.
+2. Click the entry to open it.
+
+### 3. Edit the details
+
+1. Click **Edit**.
+2. Change the fields that you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the product. |
+| Slug | The short reference for the product. |
+| Product Type | The type of the product. |
+| Category | The category of the product. |
+| Code | The code of the product. |
+| Base Unit | The unit that Care uses to count the product. |
+| Status | The current state of the catalog entry. |
+| Alternate Identifier | An additional identifier for the product. |
+| Alternate names | Other names for the same product. |
+| Storage guidelines | The storage instructions for the product. |
+
+Note: Which fields are mandatory depends on your deployment's configuration.
+
+### 4. Save the changes
+
+1. Save the entry.
+
+### 5. Retire the entry
+
+Care does not remove a catalog entry. If you no longer use a product, retire the entry.
+
+1. Open the catalog entry.
+2. Click **Delete**.
+3. Care sets the Status of the entry to Retired.
+
+## Expected Outcome
+
+- The catalog entry shows the updated details.
+- A retired entry has the status Retired, and stays in the catalog.
+
+## Related
+
+Concepts:
+
+- [Product](../../../concepts/supply/product.mdx)
+
+Flows:
+
+- [Add a product to the catalog](./add-product-to-catalog.mdx)
+- [Add a product instance](./add-product-instance.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-delivery/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/purchase-delivery/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Purchase Delivery",
+  "position": 5,
+  "key": "supply-purchase-delivery-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/purchase-delivery/add-items-purchase-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-delivery/add-items-purchase-delivery.mdx
@@ -1,0 +1,77 @@
+---
+sidebar_position: 2
+---
+
+# Add delivered items to a purchase delivery
+
+## Overview
+
+This flow describes how to add the delivered items to a [purchase delivery](../../../concepts/supply/purchase-delivery.mdx) in Care. Each item records the product, the quantity, and the condition of the goods.
+
+## Pre-requisites
+
+- You created the purchase delivery at your facility. See [Create a purchase delivery](./create-purchase-delivery.mdx).
+- The purchase delivery is not Completed, Abandoned, or Entered in Error.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create External Supply Delivery on Facility | Lets you add delivered items to a purchase delivery at the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the purchase delivery
+
+Open the purchase delivery that you want to update.
+
+Note: If you start the delivery from a purchase order, Care can load the requested items of that order automatically.
+
+### 2. Start a new item
+
+Click **Add Item**.
+
+### 3. Select the product
+
+Select the [product](../../../concepts/supply/product.mdx) that the supplier delivers. Select an existing product instance, or create a new product instance for a new batch.
+
+For a new product instance, enter the values below.
+
+| Components | What it captures |
+| --- | --- |
+| Lot Number | The batch number of the delivered goods. |
+| Expiration Date | The date on which the batch expires. |
+| Purchase Price | The price that you pay for the product. |
+| Pack Size | The number of units in one pack. |
+
+### 4. Enter the delivered quantity
+
+Enter the quantity that the supplier delivers. You can enter the pack quantity and the pack size instead.
+
+### 5. Enter the charges and the condition
+
+Enter the tax amount and the discount amount for the item. Select the condition of the delivered goods: **Normal** or **Damaged**.
+
+Note: Which fields are mandatory depends on your deployment's configuration.
+
+### 6. Save the item
+
+Save the item. Repeat the steps above for each delivered product.
+
+## Expected Outcome
+
+- Care adds the item to the purchase delivery.
+- The purchase delivery shows each delivered product, its quantity, and its condition.
+
+## Related
+
+Concepts:
+
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+- [Product](../../../concepts/supply/product.mdx)
+
+Flows:
+
+- [Create a purchase delivery](./create-purchase-delivery.mdx)
+- [Receive and complete a purchase delivery](./receive-purchase-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-delivery/create-purchase-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-delivery/create-purchase-delivery.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 1
+---
+
+# Create a purchase delivery
+
+## Overview
+
+This flow describes how to create a [purchase delivery](../../../concepts/supply/purchase-delivery.mdx) for a location in a facility. The delivery starts as a Draft.
+
+## Pre-requisites
+
+- You are a member of the facility that receives the delivery.
+- Your facility has the location that receives the delivery.
+- If you start from a purchase order, someone created that [purchase order](../../../concepts/supply/purchase-order.mdx) at your facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create External Supply Delivery on Facility | Lets you create a purchase delivery for a location in the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the inventory of the location
+
+Open the facility. Select the location that receives the delivery. Select **Inventory**. Go to the external deliveries area.
+
+### 2. Start the delivery
+
+Click **Create Delivery**.
+
+Note: You can also start the delivery from an existing purchase order. Care fills the name, the vendor, the destination, and the tags for you. Care locks the destination.
+
+### 3. Enter the delivery details
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the delivery. |
+| Note | More information about the delivery. This field is optional. |
+| Vendor/Distributor | The vendor or distributor that supplies the items. |
+| Destination | The location that receives the items. Care sets the current location by default. |
+
+If you start from a purchase order, check the filled values.
+
+### 4. Create the delivery
+
+Create the delivery. Care saves the delivery with the status Draft.
+
+## Expected Outcome
+
+- Care creates the purchase delivery with the status Draft.
+- The delivery contains no items. You add the items in a separate step.
+
+## Related
+
+Concepts:
+
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+- [Purchase Order](../../../concepts/supply/purchase-order.mdx)
+
+Flows:
+
+- [Add delivered items to a purchase delivery](./add-items-purchase-delivery.mdx)
+- [View a purchase delivery](./view-purchase-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-delivery/receive-purchase-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-delivery/receive-purchase-delivery.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 3
+---
+
+# Receive and complete a purchase delivery
+
+## Overview
+
+This flow describes how to approve a [purchase delivery](../../../concepts/supply/purchase-delivery.mdx), record the goods you receive, and complete the delivery in Care. When you complete the delivery, Care updates the stock counts of the [inventory items](../../../concepts/supply/inventory-item.mdx) at the destination location.
+
+## Pre-requisites
+
+- You created the purchase delivery, and you added the delivered items to it. See [Add delivered items to a purchase delivery](./add-items-purchase-delivery.mdx).
+- The purchase delivery is in the Draft status.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create External Supply Delivery on Facility | Lets you approve, receive, and complete a purchase delivery at the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the purchase delivery
+
+Open the purchase delivery that you want to receive.
+
+### 2. Approve the delivery
+
+Click **Mark as Approved**. Care moves the delivery from Draft to Pending.
+
+### 3. Record the goods you receive
+
+Wait until the goods arrive at the destination location. Mark the delivery as received. Confirm the condition of each item. Select Normal or Damaged for each item.
+
+### 4. Complete the delivery
+
+Click **Mark as Completed**. Care updates the stock counts of the inventory items at the destination location.
+
+Note: If the delivery is linked to a patient, the delivery is a medication return. Care then creates a refund [invoice](../../../concepts/billing/invoice.mdx) and reversed charge items on the billing account of that patient.
+
+## Expected Outcome
+
+- The purchase delivery is in the Completed status.
+- The stock counts of the inventory items at the destination location show the goods you receive.
+- Each delivered item shows the condition that you confirm: Normal or Damaged.
+- For a delivery that is linked to a patient, the billing account of that patient shows a refund invoice and reversed charge items.
+
+## Related
+
+Concepts:
+
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+- [Inventory Item](../../../concepts/supply/inventory-item.mdx)
+- [Invoice](../../../concepts/billing/invoice.mdx)
+
+Flows:
+
+- [Add delivered items to a purchase delivery](./add-items-purchase-delivery.mdx)
+- [View a purchase delivery](./view-purchase-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-delivery/view-purchase-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-delivery/view-purchase-delivery.mdx
@@ -1,0 +1,75 @@
+---
+sidebar_position: 4
+---
+
+# View a purchase delivery
+
+## Overview
+
+This flow describes how to open a [purchase delivery](../../../concepts/supply/purchase-delivery.mdx) in Care and read its details. You can also print a copy of the delivery.
+
+## Pre-requisites
+
+- You are a member of the facility that receives the delivery.
+- Someone created the purchase delivery at that facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Supply Delivery | Lets you open a purchase delivery and read its details. |
+
+Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission.
+
+## Steps
+
+### 1. Open the facility
+
+Go to the facility that receives the delivery.
+
+### 2. Select the location
+
+Select the location that holds the delivered items.
+
+### 3. Open Inventory
+
+Click **Inventory**. Care shows the list of external deliveries for the location.
+
+### 4. Open the delivery
+
+Select a delivery in the list. Care opens the delivery page.
+
+### 5. Read the delivery details
+
+The delivery page shows the following details.
+
+| Components | What it shows |
+| --- | --- |
+| Name | The name of the delivery. |
+| Note | The note that a user added to the delivery. |
+| Vendor | The vendor that supplies the items. |
+| Destination | The location that receives the items. |
+| Status | The current status of the delivery. |
+| Delivered items | The product, quantity, price, and condition of each item. |
+
+### 6. Print the delivery
+
+Click **Print** to produce a printable copy of the delivery.
+
+## Expected Outcome
+
+- You see the name, note, vendor, destination, and status of the purchase delivery.
+- You see the product, quantity, price, and condition of each delivered item.
+- You get a printable copy of the delivery when you click **Print**.
+
+## Related
+
+Concepts:
+
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+
+Flows:
+
+- [Create a purchase delivery](./create-purchase-delivery.mdx)
+- [Receive and complete a purchase delivery](./receive-purchase-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-order/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/purchase-order/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Purchase Order",
+  "position": 3,
+  "key": "supply-purchase-order-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/purchase-order/add-items-purchase-order.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-order/add-items-purchase-order.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 2
+---
+
+# Add items to a purchase order
+
+## Overview
+
+This flow describes how to add the products you request to a [purchase order](../../../concepts/supply/purchase-order.mdx) in Care. Each item records one product and the quantity you request.
+
+## Pre-requisites
+
+- You created a purchase order at the facility. See [Create a purchase order](./create-purchase-order.mdx).
+- The purchase order is not Completed, Abandoned, or Entered in Error.
+- Someone added the product that you request to the product catalog. See [Product](../../../concepts/supply/product.mdx).
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Request on Facility | Lets you add items to a purchase order at the facility. Facility Admin, Admin, Staff, Doctor, and Nurse have this permission. |
+
+## Steps
+
+### 1. Open the purchase order
+
+Open the purchase order that you want to add items to.
+
+### 2. Start a new item
+
+Click **Add Item**.
+
+Note: Care does not show **Add Item** when the purchase order is Completed, Abandoned, or Entered in Error.
+
+### 3. Enter the item details
+
+Complete the item fields.
+
+| Components | What it captures |
+| --- | --- |
+| Product | The product that you request. |
+| Quantity | The quantity that you request for the product. |
+
+### 4. Add the remaining items
+
+Repeat the previous steps for each product that you need on the purchase order.
+
+## Expected Outcome
+
+- The purchase order lists each item that you added.
+- The detail page shows the requested quantity for each item.
+- The detail page shows the dispatched quantity for each item.
+- The detail page shows the remaining quantity for each item.
+
+## Related
+
+Concepts:
+
+- [Purchase Order](../../../concepts/supply/purchase-order.mdx)
+- [Product](../../../concepts/supply/product.mdx)
+
+Flows:
+
+- [Create a purchase order](./create-purchase-order.mdx)
+- [View a purchase order](./view-purchase-order.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-order/create-purchase-order.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-order/create-purchase-order.mdx
@@ -1,0 +1,73 @@
+---
+sidebar_position: 1
+---
+
+# Create a purchase order
+
+## Overview
+
+This flow describes how to create a [purchase order](../../../concepts/supply/purchase-order.mdx) for a location in a facility. The new order starts as a Draft.
+
+## Pre-requisites
+
+- You are a member of the facility that requests the supplies.
+- Your facility has the location that receives the supplies.
+- Care holds a record of the vendor or distributor that supplies the items.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Request on Facility | Lets you create a purchase order for a location in the facility. Facility Admin, Admin, Staff, Doctor, and Nurse have this permission. |
+
+## Steps
+
+### 1. Open the purchase orders of a location
+
+1. Open the facility.
+2. Select a location.
+3. Select **Inventory**.
+4. Select **Purchase Orders**.
+
+### 2. Start a new order
+
+Select **Create Order**.
+
+### 3. Enter the order details
+
+Complete the form.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the purchase order. |
+| Note | More information about the order. This field is optional. |
+| Intent | The level of commitment of the order. |
+| Category | The type of supplies that you request. |
+| Priority | The urgency of the order. |
+| Reason | The reason for the order. |
+| Vendor/Distributor | The external supplier organization that provides the items. |
+| Destination | The location that receives the items. Care sets the current location by default. Confirm the value, or select a different location. |
+
+Note: Which fields are mandatory depends on your deployment's configuration.
+
+### 4. Create the order
+
+Create the order. Care saves the order with the status Draft.
+
+## Expected Outcome
+
+- Care creates the purchase order with the status Draft.
+- The order shows in the purchase orders list of the location.
+- The order has no items yet. Add the items in a separate step.
+
+## Related
+
+Concepts:
+
+- [Purchase Order](../../../concepts/supply/purchase-order.mdx)
+
+Flows:
+
+- [Add items to a purchase order](./add-items-purchase-order.mdx)
+- [View a purchase order](./view-purchase-order.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-order/update-purchase-order-status.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-order/update-purchase-order-status.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 4
+---
+
+# Update the status of a purchase order
+
+## Overview
+
+This flow describes how to move a [purchase order](../../../concepts/supply/purchase-order.mdx) forward in Care. You change the status of the order when the order progresses, or when you stop it.
+
+## Pre-requisites
+
+- Someone created the purchase order at your facility, and you open that order.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Request on Facility | Lets you create a purchase order, edit it, and change its status. |
+
+Facility Admin, Admin, Staff, Doctor, and Nurse have this permission.
+
+## Steps
+
+### 1. Open the purchase order
+
+Open the purchase order that you want to update.
+
+### 2. Start the edit
+
+Click **Edit**.
+
+Note: Care has no separate approve button or complete button. You move the order forward from the edit form.
+
+### 3. Select the new status
+
+Select the new value in the **Status** field. The table shows each status.
+
+| Status | What it means |
+| --- | --- |
+| Draft | You still prepare the order. |
+| Pending | You sent the order forward for supply. |
+| Completed | The vendor supplied everything in the order. |
+| Abandoned | You stopped the order before supply. |
+| Entered in Error | You created the order by mistake. |
+
+### 4. Save the purchase order
+
+Save the purchase order.
+
+## Expected Outcome
+
+- Care records the new status on the purchase order.
+- The purchase order shows the new status when you view it.
+
+## Related
+
+Concepts:
+
+- [Purchase Order](../../../concepts/supply/purchase-order.mdx)
+- [Purchase Delivery](../../../concepts/supply/purchase-delivery.mdx)
+
+Flows:
+
+- [View a purchase order](./view-purchase-order.mdx)

--- a/versioned_docs/version-3.1/flows/supply/purchase-order/view-purchase-order.mdx
+++ b/versioned_docs/version-3.1/flows/supply/purchase-order/view-purchase-order.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 3
+---
+
+# View a purchase order
+
+## Overview
+
+This flow describes how to open a [purchase order](../../../concepts/supply/purchase-order.mdx) in Care and read its details. You can also print a copy of the order.
+
+## Pre-requisites
+
+- You are a member of the facility that places the order.
+- Someone created a purchase order for a location in that facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Supply Request | Lets you open a purchase order and read its details. |
+
+Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission.
+
+## Steps
+
+### 1. Open the location inventory
+
+Go to the facility. Select the location. Select **Inventory**.
+
+### 2. Open the purchase orders list
+
+Select **Purchase Orders**. Care shows the purchase orders for the location.
+
+### 3. Open the purchase order
+
+Select the purchase order that you want to read. Care opens the purchase order page.
+
+### 4. Read the purchase order details
+
+The purchase order page shows these details.
+
+| Components | What it shows |
+| --- | --- |
+| Name | The name of the purchase order. |
+| Note | The note that the user added to the order. |
+| Intent | The intent of the order. |
+| Category | The category of the order. |
+| Priority | The priority of the order. |
+| Reason | The reason for the order. |
+| Vendor | The vendor that supplies the items. |
+| Destination | The location that receives the items. |
+| Status | The current status of the order. |
+
+The page also shows the requested items. Each item shows the requested quantity, the dispatched quantity, and the remaining quantity.
+
+### 5. Print the purchase order
+
+Select **Print**. Care creates a printable copy of the purchase order.
+
+## Expected Outcome
+
+- Care shows the purchase order details and its requested items.
+- Care creates a printable copy of the purchase order when you select **Print**.
+
+## Related
+
+Concepts:
+
+- [Purchase Order](../../../concepts/supply/purchase-order.mdx)
+
+Flows:
+
+- [Create a purchase order](./create-purchase-order.mdx)
+- [Add items to a purchase order](./add-items-purchase-order.mdx)
+- [Update the status of a purchase order](./update-purchase-order-status.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-delivery/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/supply-delivery/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Supply Delivery",
+  "position": 6,
+  "key": "supply-supply-delivery-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/supply-delivery/add-items-supply-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-delivery/add-items-supply-delivery.mdx
@@ -1,0 +1,60 @@
+---
+sidebar_position: 2
+---
+
+# Add delivered items to a supply delivery
+
+## Overview
+
+This flow describes how to add the items that you move in a [supply delivery](../../../concepts/supply/supply-delivery.mdx). Each item names a batch in stock and the quantity to move.
+
+## Pre-requisites
+
+- You created the supply delivery at your facility. See [Create a supply delivery](./create-supply-delivery.mdx).
+- The supply delivery is not Completed, Abandoned, or Entered in Error.
+- The batch that you move is in stock at the source location.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Delivery on Facility | Lets you add delivered items to a supply delivery at the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the supply delivery
+
+Open the supply delivery that you want to add items to.
+
+### 2. Start a new item
+
+Click **Add Item**.
+
+Note: If you start the delivery from a supply order, Care can load the requested items for you.
+
+### 3. Select the inventory item
+
+Select an existing inventory item. An inventory item is one batch that is already in stock at the source location.
+
+### 4. Enter the quantity
+
+Enter the quantity to move for that batch.
+
+Note: Care does not allow a quantity that is more than the stock at the source location.
+
+## Expected Outcome
+
+- The supply delivery lists the item, the batch, and the quantity to move.
+
+## Related
+
+Concepts:
+
+- [Supply Delivery](../../../concepts/supply/supply-delivery.mdx)
+- [Inventory Item](../../../concepts/supply/inventory-item.mdx)
+
+Flows:
+
+- [Create a supply delivery](./create-supply-delivery.mdx)
+- [Receive and complete a supply delivery](./receive-supply-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-delivery/create-supply-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-delivery/create-supply-delivery.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 1
+---
+
+# Create a supply delivery
+
+## Overview
+
+This flow describes how to create a [supply delivery](../../../concepts/supply/supply-delivery.mdx) in Care. The
+delivery starts as a Draft, and you add the delivered items in a separate step.
+
+## Pre-requisites
+
+- You are a member of the facility that sends the stock.
+- Your facility has the source location and the destination location.
+- If you start from a [supply order](../../../concepts/supply/supply-request.mdx), someone raised
+  that order at your facility.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Delivery on Facility | Lets you create a supply delivery for the facility. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the outgoing deliveries list
+
+Open the facility. Select a location. Select **Inventory**. Select **To Dispatch**. Select
+the **Outgoing Deliveries** tab.
+
+Note: You can also start this flow from an existing supply order. The supply order
+fills in the name, the source location, the destination, and the tags for you.
+
+### 2. Start a new delivery
+
+Click **Create Delivery**.
+
+### 3. Enter the delivery details
+
+Complete the fields in the form.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the delivery. |
+| Note | More information about the delivery. This field is optional. |
+| Deliver From | The location that supplies the stock. |
+| Destination | The location that receives the stock. This field defaults to the current location. |
+
+If you start from a supply order, Care fills in these fields. Confirm the **Deliver
+From** location. Confirm the **Destination** location.
+
+### 4. Create the delivery
+
+Create the delivery. Care saves the delivery with the status Draft.
+
+## Expected Outcome
+
+- Care creates the supply delivery with the status Draft.
+- The delivery shows in the **Outgoing Deliveries** tab of the source location.
+- You can now add the delivered items to the delivery.
+
+## Related
+
+Concepts:
+
+- [Supply Delivery](../../../concepts/supply/supply-delivery.mdx)
+- [Supply Order](../../../concepts/supply/supply-request.mdx)
+
+Flows:
+
+- [Add delivered items to a supply delivery](./add-items-supply-delivery.mdx)
+- [View a supply delivery](./view-supply-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-delivery/receive-supply-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-delivery/receive-supply-delivery.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+---
+
+# Receive and complete a supply delivery
+
+## Overview
+
+This flow describes how to approve a [supply delivery](../../../concepts/supply/supply-delivery.mdx), confirm the delivered items at the receiving location, and complete the delivery in Care.
+
+## Pre-requisites
+
+- You created the supply delivery, and it lists the items that you send. See [Add delivered items to a supply delivery](./add-items-supply-delivery.mdx).
+- You are a member of the facility that dispatches or receives the delivery.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Delivery on Facility | Lets you approve, confirm, and complete a supply delivery. Facility Admin and Admin have this permission. |
+
+## Steps
+
+### 1. Open the supply delivery
+
+1. Go to the Inventory screen of the dispatching location or the receiving location.
+2. Select **To Dispatch** to see **Outgoing Deliveries**.
+3. Select **To Receive** to see **Incoming Deliveries**.
+4. Select the supply delivery that you want to receive.
+
+### 2. Approve the supply delivery
+
+1. Select **Mark as Approved**.
+2. Care moves the supply delivery from Draft to Pending.
+
+### 3. Confirm the delivered items
+
+1. Confirm each item in the supply delivery at the receiving location.
+2. Record the condition of each item as Normal or Damaged.
+
+### 4. Complete the supply delivery
+
+1. Select **Mark as Completed**.
+2. Care deducts the stock from the [inventory item](../../../concepts/supply/inventory-item.mdx) of the source location.
+3. Care adds the stock to the inventory item of the destination location.
+
+## Expected Outcome
+
+- The supply delivery status is Completed.
+- The stock of the source location decreases by the delivered quantity.
+- The stock of the destination location increases by the delivered quantity.
+
+## Related
+
+Concepts:
+
+- [Supply Delivery](../../../concepts/supply/supply-delivery.mdx)
+- [Inventory Item](../../../concepts/supply/inventory-item.mdx)
+
+Flows:
+
+- [Add delivered items to a supply delivery](./add-items-supply-delivery.mdx)
+- [View a supply delivery](./view-supply-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-delivery/view-supply-delivery.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-delivery/view-supply-delivery.mdx
@@ -1,0 +1,75 @@
+---
+sidebar_position: 4
+---
+
+# View a supply delivery
+
+## Overview
+
+This flow describes how to open a [supply delivery](../../../concepts/supply/supply-delivery.mdx) in Care and read its details. You can also print a copy of the delivery.
+
+## Pre-requisites
+
+- Someone created the supply delivery at your facility.
+- You are a member of the facility that dispatches or receives the delivery.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Supply Delivery | Lets you open a supply delivery and read its details. |
+
+Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission.
+
+## Steps
+
+### 1. Open the facility location
+
+Select your facility. Open the location that holds the delivery.
+
+### 2. Open the inventory
+
+Click **Inventory**.
+
+### 3. Select the delivery list
+
+Click **To Dispatch** to see the deliveries that leave the location. Click **To Receive** to see the deliveries that come to the location. Open the deliveries tab.
+
+### 4. Open the delivery
+
+Select a delivery from the list. Care opens the delivery page.
+
+### 5. Read the delivery details
+
+The delivery page shows the details in the table below.
+
+| Components | What it shows |
+| --- | --- |
+| Name | The name of the supply delivery. |
+| Note | The note that the user added to the delivery. |
+| Deliver From | The source location of the delivery. |
+| Destination | The location that receives the delivery. |
+| Status | The current status of the delivery. |
+| Delivered items | Each inventory item in the delivery and the quantity moved. |
+
+### 6. Print the delivery
+
+Click **Print**. Care creates a printable copy of the delivery.
+
+## Expected Outcome
+
+- You see the name, note, source location, destination, and status of the supply delivery.
+- You see each delivered item with the quantity moved.
+- You get a printable copy of the delivery when you click **Print**.
+
+## Related
+
+Concepts:
+
+- [Supply Delivery](../../../concepts/supply/supply-delivery.mdx)
+
+Flows:
+
+- [Create a supply delivery](./create-supply-delivery.mdx)
+- [Receive and complete a supply delivery](./receive-supply-delivery.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-request/_category_.json
+++ b/versioned_docs/version-3.1/flows/supply/supply-request/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Supply Order",
+  "position": 4,
+  "key": "supply-supply-request-flows"
+}

--- a/versioned_docs/version-3.1/flows/supply/supply-request/add-items-supply-request.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-request/add-items-supply-request.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 2
+---
+
+# Add items to a supply request
+
+## Overview
+
+This flow describes how to add the products that you need to a [supply request](../../../concepts/supply/supply-request.mdx) in Care.
+
+## Pre-requisites
+
+- You raised the supply request at your facility. See [Raise a supply request](./raise-supply-request.mdx).
+- The supply request is not Completed, Abandoned, or Entered in Error.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Request on Facility | Lets you add items to a supply request at the facility. Facility Admin, Admin, Staff, Doctor, and Nurse have this permission. |
+
+## Steps
+
+### 1. Open the supply request
+
+Open the supply request that you want to add items to.
+
+### 2. Start a new item
+
+Click **Add Item**.
+
+### 3. Enter the item details
+
+Complete the fields for the item.
+
+| Components | What it captures |
+| --- | --- |
+| Product | The catalog entry that you request. |
+| Quantity | The amount of the product that you request. |
+
+### 4. Repeat for each item
+
+Repeat steps 2 and 3 for each item that you need on the request.
+
+## Expected Outcome
+
+- The supply request holds the items that you added.
+- The detail page of the request shows, for each item, the quantity requested, the quantity dispatched, and the quantity that remains.
+
+## Related
+
+Concepts:
+
+- [Supply Order](../../../concepts/supply/supply-request.mdx)
+- [Product](../../../concepts/supply/product.mdx)
+
+Flows:
+
+- [Raise a supply request](./raise-supply-request.mdx)
+- [View a supply request](./view-supply-request.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-request/raise-supply-request.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-request/raise-supply-request.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+---
+
+# Raise a supply request
+
+## Overview
+
+This flow describes how to raise a [supply request](../../../concepts/supply/supply-request.mdx) from one location to another location in the same facility. Care creates the request as a draft order.
+
+## Pre-requisites
+
+- You are a member of the facility.
+- The facility has more than one location, because you request stock from another location.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Request on Facility | Lets you raise a supply request in the facility. Facility Admin, Admin, Staff, Doctor, and Nurse have this permission. |
+
+## Steps
+
+### 1. Open the inventory of the location
+
+1. Open the facility.
+2. Select the location that needs the stock.
+3. Select **Inventory**.
+
+### 2. Open the requests you raised
+
+1. Select **To Receive**.
+2. Select the **Requests Raised** tab.
+
+### 3. Start a new request
+
+Click **Raise Stock Request**.
+
+### 4. Fill in the request details
+
+Complete the form fields.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the supply request. |
+| Note | More information about the request. This field is optional. |
+| Intent | The level of authority of the request, for example a proposal or an order. |
+| Category | The type of supply that you request. |
+| Priority | The urgency of the request. |
+| Reason | Why you raise the request. |
+| Deliver From | The location that supplies the stock. Select another location in the same facility. |
+| Destination | The location that receives the stock. Care sets the current location by default. |
+
+Note: Which fields are mandatory depends on your deployment's configuration.
+
+### 5. Create the request
+
+Create the supply request. Care saves the request with the status Draft.
+
+## Expected Outcome
+
+- Care creates the supply request and shows it in the **Requests Raised** tab.
+- The supply request has the status Draft.
+- The supply request has no items yet. Add the items in a separate step.
+
+## Related
+
+Concepts:
+
+- [Supply Order](../../../concepts/supply/supply-request.mdx)
+
+Flows:
+
+- [Add items to a supply request](./add-items-supply-request.mdx)
+- [View a supply request](./view-supply-request.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-request/update-supply-request-status.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-request/update-supply-request-status.mdx
@@ -1,0 +1,67 @@
+---
+sidebar_position: 4
+---
+
+# Update the status of a supply request
+
+## Overview
+
+This flow describes how to move a [supply request](../../../concepts/supply/supply-request.mdx) forward in Care. You change the status of the request when you edit it.
+
+Note: Care has no separate approve button or complete button. You change the Status field to move the request forward.
+
+## Pre-requisites
+
+- Someone raised the supply request at your facility, and you open that request.
+- You are a member of the facility that holds the supply request.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Supply Request on Facility | Lets you create a supply request, edit it, and change its status. Facility Admin, Admin, Staff, Doctor, and Nurse have this permission. |
+
+## Steps
+
+### 1. Open the supply request
+
+Open the supply request that you want to update.
+
+### 2. Start the edit
+
+Click **Edit**.
+
+### 3. Change the status
+
+Select the new value in the **Status** field.
+
+| Status | What it means |
+| --- | --- |
+| Draft | You prepare the request. The request is not yet submitted. |
+| Pending | The request waits for action. |
+| Completed | The facility dispatched all of the requested items. |
+| Abandoned | The facility stopped the request. |
+| Entered in Error | Someone created the request by mistake. |
+
+Note: Select Pending when you move a request out of Draft. Select Completed after the facility dispatches the full request.
+
+### 4. Save the change
+
+Save the supply request.
+
+## Expected Outcome
+
+- Care records the new status on the supply request.
+- The supply request shows the new status when you view it.
+
+## Related
+
+Concepts:
+
+- [Supply Order](../../../concepts/supply/supply-request.mdx)
+- [Supply Delivery](../../../concepts/supply/supply-delivery.mdx)
+
+Flows:
+
+- [View a supply request](./view-supply-request.mdx)

--- a/versioned_docs/version-3.1/flows/supply/supply-request/view-supply-request.mdx
+++ b/versioned_docs/version-3.1/flows/supply/supply-request/view-supply-request.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 3
+---
+
+# View a supply request
+
+## Overview
+
+This flow describes how to open a [supply request](../../../concepts/supply/supply-request.mdx) in Care and read its details. You can also print a copy of the request.
+
+## Pre-requisites
+
+- You are a member of the facility that raises or fulfills the supply request.
+- Someone raised the supply request at the facility.
+- You have the permission listed below.
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Read Supply Request | Lets you open a supply request and read its details. Facility Admin, Administrator, Admin, Staff, Doctor, Nurse, Volunteer, and Pharmacist have this permission. |
+
+## Steps
+
+### 1. Open the facility inventory
+
+Go to the facility.
+
+Select a location.
+
+Select **Inventory**.
+
+### 2. Select the request list
+
+Select **To Dispatch** to see the requests that your location fulfills.
+
+Select **To Receive** to see the requests that your location raised.
+
+### 3. Open the supply request
+
+Select a supply request from the list.
+
+The request page shows the following details.
+
+| Components | What it shows |
+| --- | --- |
+| Name | The name of the supply request. |
+| Note | The note that the requester added. |
+| Intent | The intent of the supply request. |
+| Category | The category of the supply request. |
+| Priority | The priority of the supply request. |
+| Reason | The reason for the supply request. |
+| Deliver From | The source location of the supplies. |
+| Destination | The location that receives the supplies. |
+| Status | The current status of the supply request. |
+| Requested items | Each item with its requested, dispatched, and remaining quantity. |
+
+### 4. Print the supply request
+
+Select **Print** to get a printable copy of the supply request.
+
+## Expected Outcome
+
+- You see the details of the supply request and its requested items.
+- You get a printable copy of the supply request when you select **Print**.
+
+## Related
+
+Concepts:
+
+- [Supply Order](../../../concepts/supply/supply-request.mdx)
+
+Flows:
+
+- [Raise a supply request](./raise-supply-request.mdx)
+- [Add items to a supply request](./add-items-supply-request.mdx)
+- [Update the status of a supply request](./update-supply-request-status.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -296,6 +296,74 @@
               ]
             }
           ]
+        },
+        {
+          "type": "category",
+          "label": "Supply",
+          "key": "supply-flows",
+          "items": [
+            {
+              "type": "category",
+              "label": "Product",
+              "key": "supply-product-flows",
+              "items": [
+                "flows/supply/product/add-product-to-catalog",
+                "flows/supply/product/edit-retire-catalog-entry",
+                "flows/supply/product/add-product-instance",
+                "flows/supply/product/edit-product-instance"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Inventory Item",
+              "key": "supply-inventory-item-flows",
+              "items": ["flows/supply/inventory-item/view-stock-levels"]
+            },
+            {
+              "type": "category",
+              "label": "Purchase Order",
+              "key": "supply-purchase-order-flows",
+              "items": [
+                "flows/supply/purchase-order/create-purchase-order",
+                "flows/supply/purchase-order/add-items-purchase-order",
+                "flows/supply/purchase-order/view-purchase-order",
+                "flows/supply/purchase-order/update-purchase-order-status"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Supply Order",
+              "key": "supply-supply-request-flows",
+              "items": [
+                "flows/supply/supply-request/raise-supply-request",
+                "flows/supply/supply-request/add-items-supply-request",
+                "flows/supply/supply-request/view-supply-request",
+                "flows/supply/supply-request/update-supply-request-status"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Purchase Delivery",
+              "key": "supply-purchase-delivery-flows",
+              "items": [
+                "flows/supply/purchase-delivery/create-purchase-delivery",
+                "flows/supply/purchase-delivery/add-items-purchase-delivery",
+                "flows/supply/purchase-delivery/receive-purchase-delivery",
+                "flows/supply/purchase-delivery/view-purchase-delivery"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Supply Delivery",
+              "key": "supply-supply-delivery-flows",
+              "items": [
+                "flows/supply/supply-delivery/create-supply-delivery",
+                "flows/supply/supply-delivery/add-items-supply-delivery",
+                "flows/supply/supply-delivery/receive-supply-delivery",
+                "flows/supply/supply-delivery/view-supply-delivery"
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## What

Publishes the six **Supply Delivery and Inventory** modules from `care_docs` into the docs site (version 3.1). 21 flows, 4 refreshed concepts and 2 new ones.

| Module | Flows | Concept |
| --- | --- | --- |
| Product | 4 | replaced |
| Inventory Item | 1 | replaced |
| Purchase Order | 4 | **new** |
| Supply Order | 4 | replaced (`supply-request`) |
| Purchase Delivery | 4 | **new** |
| Supply Delivery | 4 | replaced |

Adds a `Supply` category to the 3.1 flows sidebar with the six modules nested under it.

## Supply Order

The `Supply Order` module publishes to `concepts/supply/supply-request.mdx`, replacing the existing page rather than creating a near-duplicate beside it. The authored concept links to the FHIR **SupplyRequest** resource and all four of its flows are titled "...a supply request", so this is the same subject.

The authored wording is kept as written, so the page is now titled **Supply Order** at `/concepts/supply/supply-request`. If the site should stay on the term "Supply Request", the concept title and body need a terminology pass — happy to do that separately.

## Purchase Order and Purchase Delivery

Both are new concepts with no previous page. They sit alongside Supply Order and Supply Delivery, covering stock coming in from an external supplier as opposed to moving between locations inside a facility.

## Note for reviewers

The four existing concepts are **replaced**, not extended.

These modules cross-reference each other and also reach into Billing — several flows link to the Invoice concept. All links resolve in the build.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
