### PR TITLE
Add Roles and Governance docs for 3.1

### DIFF
--- a/versioned_docs/version-3.1/concepts/access-governance/access-control.mdx
+++ b/versioned_docs/version-3.1/concepts/access-governance/access-control.mdx
@@ -2,89 +2,71 @@
 sidebar_position: 1
 ---
 
-# Roles & Permissions
+# Roles and Permission
 
-Roles and permissions are how Care decides **who can do what, and where**. A permission is a single action ("Can Create Patient"), a role bundles permissions into a job-shaped set ("Doctor"), and a grant gives a person that role inside one boundary — a facility, an organization, or a single patient.
+## Definition
 
-## What it represents
+A **role** in Care is a named set of permissions. A permission allows one action, for example to register a patient. Care builds every permission into the product, so you cannot create or change a permission. You group permissions into a role, and then you give the role to a user.
 
-There is no single FHIR resource for access control. Care builds it from three primitives that only mean something together:
+Note: Roles and permissions belong to Care's access control. FHIR R5 has no resource for them, so this concept has no FHIR reference.
 
-- **Permission** — the smallest unit of access: one action, declared in code (for example `can_create_patient`). Permissions are reference data; users never edit them.
-- **Role** — a flat, named bundle of permissions (Doctor, Nurse, Admin). A role is just a permission set — not a job title, not a person.
-- **Grant** — a role handed to a user *within a context*. The same person can be a Doctor at one facility, an Admin of a district, and have no access anywhere else.
+You reach roles from the Admin sidebar. Select **RBAC**, then select **Roles**. To see the permissions of every role, select **RBAC**, then select **Permissions**.
 
-The key insight: a user has **no standing powers of their own**. Every ability comes from a role granted at a specific place. Move them to a new facility and their old access does not follow — it was scoped to the boundary where it was granted.
+Note: Only a super administrator can create, change, or clone a role.
 
-## How a grant works
+## Key Attributes
 
-A grant always answers three questions — *who*, *what role*, *where*:
-
-```text
-User  ──granted──▶  Role  ──scoped to──▶  Context (facility / organization / patient)
-```
-
-The same role at a different context is a separate grant. A grant can also carry an **expiry**, after which it is meant to lapse — handy for locum cover or temporary staff. One user can hold many grants at once; their effective access on any record is the union of every role that reaches it.
-
-## How access cascades
-
-Two things make this manageable at scale rather than a grant-per-record chore.
-
-First, **permissions are context-aware**. Each permission is scoped to a kind of resource, and Care only considers permissions whose context matches what is being acted on. This is why a permission to view a patient does not also let someone administer a facility — they live in different contexts.
-
-| Context | Applies to |
+| Components | What it captures |
 | --- | --- |
-| `GENERIC` | Actions not tied to a specific resource |
-| `FACILITY` | A facility |
-| `PATIENT` | A patient record |
-| `ENCOUNTER` | A single encounter |
-| `ORGANIZATION` | A government or role (user-group) organization |
-| `FACILITY_ORGANIZATION` | A department or unit inside a facility |
-| `QUESTIONNAIRE` | A questionnaire |
+| Name | The name of the role. The name is required and must be unique. |
+| Description | A short text that explains the purpose of the role. The description is optional. |
+| Contexts | The places where you can assign the role. Select one or more contexts. |
+| Permissions | The actions that the role allows. Select one or more permissions. |
 
-Second, **grants flow down the organization tree**. Care's [organizations](../access-governance/organization.mdx) nest — State → District → Local body → Facility — and a role granted at a node reaches everything beneath it. Grant an Administrator at the district level and they act across every facility in that district with no per-facility grant; grant a role on one facility and it reaches only that facility and its units. The same logic covers patients: a clinician's role at a facility lets them work with the patients seen there, instead of a grant per patient.
+### Contexts
 
-So you grant broadly at the top of the tree for oversight, and narrowly at a facility or department for day-to-day staff.
+A context tells Care where a role applies. A role has one or more of these contexts:
 
-## Standard roles
+- **Facility** — you can give the role to a user who works in a facility.
+- **Government Organization** — you can give the role to a user in a government organization.
+- **Responsibility** — you can give the role to a user in a responsibility organization.
 
-Every Care deployment ships with these roles. They are platform-maintained — the API will not let anyone edit or delete them — and deployments can add custom roles alongside. A role's *boundaries* are the kinds of context it can be granted in; note that a role name alone is not unique, since "Admin" exists both as a facility role and as a separate role-organization role, distinguished only by boundary.
+### System roles
 
-| Role | Description | Boundaries it applies in |
-| --- | --- | --- |
-| Doctor | Clinician at a facility | Facility, Government org |
-| Nurse | Nurse at a facility | Facility, Government org |
-| Staff | General staff at a facility | Facility, Government org |
-| Volunteer | Volunteer at a facility | Facility, Government org |
-| Pharmacist | Pharmacist at a facility | Facility |
-| Administrator | Administrator at a given boundary | Facility, Government org |
-| Facility Admin | Facility administrator, assigned to whoever creates the facility | Facility |
-| Admin | Top-level administrator | Facility, Government org |
-| Admin (role org) | Administrator of a role (user-group) organization | Role org |
-| Manager (role org) | Manager of a role organization | Role org |
-| Member (role org) | Member of a role organization | Role org |
+Care includes system roles. A system role shows a **System** badge and a lock icon in the roles list. You cannot edit or delete a system role. To start from a system role, clone it into a new custom role, and then change the clone.
 
-## Permissions
+The system roles are Volunteer, Doctor, Nurse, Staff, Pharmacist, Administrator, Facility Admin, and Admin.
 
-Permissions are declared in code per resource area and assigned to standard roles by default. The slice below — the organization and user permissions — shows which roles hold each out of the box; custom roles can take any subset.
+Care also includes three system roles for the Responsibility context: Admin, Manager, and Member.
 
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_create_organization` | Create a new organization under an accessible parent (checked by the organization create flow) | Admin |
-| `can_view_organization` | View organizations; gates which organizations appear in list and retrieve | Facility Admin, Admin, Staff, Doctor, Administrator, Nurse, Volunteer, Pharmacist, Admin (role org), Manager (role org), Member (role org) |
-| `can_list_organization_users` | List the users attached to an organization | Facility Admin, Admin, Staff, Doctor, Administrator, Nurse, Volunteer, Pharmacist, Admin (role org), Manager (role org) |
-| `can_manage_organization` | Update an organization (name, description, metadata) and delete it — the update, delete, and managing-organization actions all check this | Admin, Admin (role org) |
-| `can_manage_organization_users` | Add, remove, and assign roles to users in an organization | Admin, Administrator, Facility Admin, Admin (role org) |
-| `can_manage_connected_role_organizations` | Manage users in connected role organizations | Admin (role org), Manager (role org) |
-| `can_create_user` | Create a user in Care | Admin, Facility Admin, Administrator |
-| `can_create_service_account` | Create a service-account user | Admin, Facility Admin, Administrator |
-| `can_list_user` | List users in Care | Admin, Doctor, Nurse, Administrator, Staff, Facility Admin, Volunteer, Pharmacist |
+### The permissions matrix
+
+The Permissions page shows a read-only matrix. Each row is a permission. Each column is a role. A green check mark shows that the role holds the permission. A red cross shows that the role does not hold the permission. To change what a role allows, edit the role.
+
+### How a user gets a role
+
+A user gets a role when you add the user as a member of one of these:
+
+- An organization
+- A facility, through its root department
+- A responsibility
+- A department
+
+Each membership carries exactly one role. That role decides what the user can do in that scope.
+
+Care protects access in two ways:
+
+- You can assign only a role with permissions that you also hold. You cannot give a user more access than you have.
+- Care keeps the last Facility Admin in the root department of a facility. You cannot change the role of that user. You also cannot remove the last user from the root department.
 
 ## Related
 
-- Reference: [Role](../../references/access-governance/role.mdx)
-- Reference: [Permission](../../references/access-governance/permission.mdx)
-- Reference: [Permission association](../../references/access-governance/permission-association.mdx)
-- Concept: [Organization](../access-governance/organization.mdx)
-- Concept: [Facility](../facility/facility.mdx)
-- Concept: [Patient](../clinical/patient)
+- Flow: [Create a role](../../flows/access-governance/access-control/create-role.mdx)
+- Flow: [Edit or clone a role](../../flows/access-governance/access-control/edit-or-clone-role.mdx)
+- Flow: [View the permissions matrix](../../flows/access-governance/access-control/view-permissions-matrix.mdx)
+- Flow: [Assign a role to a user](../../flows/access-governance/access-control/assign-role-to-user.mdx)
+- Flow: [Change or remove a user's role](../../flows/access-governance/access-control/change-or-remove-user-role.mdx)
+- Concept: [Organisation](../../concepts/access-governance/organization.mdx)
+- Concept: [Supplier](../../concepts/access-governance/supplier.mdx)
+- Concept: [Responsibility](../../concepts/access-governance/responsibility.mdx)
+- Concept: [User](../../concepts/access-governance/user.mdx)

--- a/versioned_docs/version-3.1/concepts/access-governance/organization.mdx
+++ b/versioned_docs/version-3.1/concepts/access-governance/organization.mdx
@@ -2,71 +2,74 @@
 sidebar_position: 2
 ---
 
-# Organization
+# Organisation
 
-An **organization** is how Care groups people and permissions so that access is defined once and reused, instead of configured per person. Organizations form a tree, and a role granted on a parent flows down to everything beneath it — they are the backbone of who-can-do-what across a deployment. (FHIR calls this grouping primitive *Organization*; Care uses that term rather than "group," which is ambiguous in a clinical setting.)
+## Definition
 
-## What it represents
+An **[organization](https://build.fhir.org/organization.html)** in Care is a government
+or administrative area, for example a state or a district. Care arranges these areas in
+a hierarchy, from the country down to the ward. To open the hierarchy, select
+**Organizations** in the Admin sidebar. Then select **Governance**.
 
-The job of an organization is to **group the permissions assigned to resources**. Rather than granting each new doctor a long list of permissions, you create a "Doctors" organization once, give it the access it should carry — hospital-wide questionnaires, say — and add doctors to it. A child "Cardiology" organization can layer on cardiology-specific forms while still inheriting everything from "Doctors." The next doctor who arrives is simply added to the group; no permissions are defined by hand.
+Care attaches an organization to each facility and to each patient as the geo
+organization. The geo organization is the government area that the facility or the
+patient belongs to, for example a district.
 
-An organization is not a facility. A facility is a physical place where care happens; an organization is an administrative grouping that lives instance-wide. The departments and teams *inside* a single hospital are modelled separately as [facility organizations](../access-governance/facility-organization.mdx) — this concept is the platform-wide tree above them.
+Note: Care uses the word "Governance" for two different things. The **Governance** item
+under **Organizations** holds the government organizations that this document describes.
+The **Governance** section inside a responsibility links one responsibility to another.
+See [Responsibility](../../concepts/access-governance/responsibility.mdx).
 
-## Organization types
+## Key Attributes
 
-The `org_type` says what kind of grouping a node is, and Care treats each differently — most visibly in who is allowed to manage it.
-
-| Type | What it is |
+| Components | What it captures |
 | --- | --- |
-| `team` | A working grouping of people — the everyday default |
-| `govt` | A governance / governmental unit that mirrors a real administrative hierarchy |
-| `role` | A **user group**: a flat set of users grouped for a shared purpose (assigning questionnaires, and later prescribing and approvals) |
-| `product_supplier` | A supplier organization that links into the [supply chain](../supply/product.mdx) |
+| Name | The name of the government or administrative area. Care requires a name. |
+| Description | More detail about the organization. This attribute is optional. |
 
-### Government hierarchies
+The name must be different from the names of the other organizations at the same level
+of the same hierarchy.
 
-`govt` organizations model real-world governance — a public-health administration laid out as `State → District → Block → Panchayat`, for example. They are the geographic backbone a deployment hangs facilities and patients off: a facility's governing organization and a patient's administrative area both point into this tree. That is how a district health officer reaches every facility and patient beneath their district without being added to each one.
+### The hierarchy
 
-Because governance structures have to be visible to coordinate across them, **anyone in Care may view `govt` organizations**, but only a superadmin may create or edit them. Their names and shape are treated as fixed reference data, not something an individual facility can change.
+Care shows the organizations as an expandable tree at the left of the page. Every
+organization, except a top-level organization, has one parent. An organization can have
+any number of children.
 
-### Role organizations (user groups)
+The government hierarchy levels include:
 
-A `role` organization is a **user group** — a flat list of users grouped for a shared purpose rather than a place in a hierarchy. Care uses them to decide things like which users a questionnaire is assigned to, and they are built to extend to prescribing, approving requests, and similar group-driven workflows. A deployment defines the groups it needs — in palliative care these might be *Volunteer*, *ASHA Worker*, or *MLSP* — and a user can be placed into them when their account is created. Unlike the governance and team trees, role organizations are flat and are managed by superadmins.
+- Country
+- State
+- District
+- Block Panchayat
+- Corporation
+- District Panchayat
+- Grama Panchayat
+- Local Body
+- Municipality
+- Ward
 
-:::note Role vs. role organization
-A **role** is an arbitrary set of permissions — `Doctor`, `Doctor (Read Only)`, `Doctor (Scheduler)` — nothing more than a named bundle, never a job title. A **role organization** is a group of users. They are independent: you grant a role to a user *within* an organization. See [Roles & permissions](../access-governance/access-control.mdx).
-:::
+Note: The set of levels that your deployment uses can be different.
 
-## How the tree works
+Note: Your deployment sets the maximum depth of the organization hierarchy.
 
-Organizations nest. A root sits at the top with no parent; every other node points to a single parent, forming chains like `Government → State Health Dept → District → Cardiology`.
+### Level and parent
 
-The defining behaviour is **inheritance**: a role granted on a parent applies implicitly to every descendant. Make someone an admin of a district and they can act across every team beneath it without being added to each. This is what makes the tree an access structure and not just a folder hierarchy.
+You do not enter the hierarchy level and the parent. Care sets them from the position in
+the tree where you create the organization.
 
-A few rules keep it consistent: siblings under the same root must have unique names; a parent cannot be deleted while it still has children; system-generated and `govt` organizations cannot be edited; and a node's parent is fixed once created — you move people, not the node.
+### Who can change the hierarchy
 
-## Membership, roles & responsibility
-
-People gain access by being added to an organization **with a role** — that triple of user + organization + role is what grants permission. Membership grants access *through* the organization, not *to* everything it touches: a user can act on the resources assigned to their organization (and, by inheritance, its descendants), always bounded by what their role allows. An organization "for nurses with access to patients in wards Y and Z" reaches exactly those patients — not every patient in the deployment.
-
-Care guards against privilege escalation right at the membership boundary: the role you assign to someone can be **at most the role you yourself hold** in that organization, and you can only remove members whose access sits below your own. No one can grant — or revoke — more than they have.
-
-Administering a *user* (resetting a password, editing details, changing group memberships) follows the same principle through a separate **management hierarchy**: a user can be administered only by someone in a managing organization above them, never by an arbitrary peer. That is how a governance admin can legitimately reset a password for someone beneath them, while no one can seize control of a user they don't already oversee.
-
-## Permissions
-
-Access to organizations is governed by the permissions below. Each lists the system roles that carry it by default.
-
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_create_organization` | Create a new organization under a parent the user can already manage (root, governance, and role organizations remain superadmin-only) | Admin |
-| `can_view_organization` | View organizations and list/retrieve them through the accessible-organizations filter | Facility Admin, Admin, Staff, Doctor, Administrator, Nurse, Volunteer, Pharmacist, Admin (role org), Manager (role org), Member (role org) |
-| `can_manage_organization` | Update an organization's name, description, and metadata, manage its connected role organizations, and delete it once it has no children | Admin, Admin (role org) |
-| `can_list_organization_users` | List the members of an organization | Facility Admin, Admin, Staff, Doctor, Administrator, Nurse, Volunteer, Pharmacist, Admin (role org), Manager (role org) |
-| `can_manage_organization_users` | Add, remove, and assign roles to members of an organization (bounded by the actor's own role privileges) | Admin, Administrator, Facility Admin, Admin (role org) |
-| `can_manage_connected_role_organizations` | Add, remove, and assign roles to members of connected role organizations | Admin (role org), Manager (role org) |
+Only a Care superuser can create, change, or delete a government organization. Other
+users see the government organizations that they have access to. Care blocks their
+changes to these organizations.
 
 ## Related
 
-- Reference: [Organization (technical)](../../references/access-governance/organization.mdx)
-- Concept: [Roles & permissions](../access-governance/access-control.mdx) · [Facility Organization](../access-governance/facility-organization.mdx) · [Facility](../facility/facility.mdx)
+- Flow: [Create an organization](../../flows/access-governance/organization/create-organization.mdx)
+- Flow: [Update an organization](../../flows/access-governance/organization/update-organization.mdx)
+- Flow: [View the organization hierarchy](../../flows/access-governance/organization/view-organization-hierarchy.mdx)
+- Flow: [Delete an organization](../../flows/access-governance/organization/delete-organization.mdx)
+- Concept: [Roles and Permission](../../concepts/access-governance/access-control.mdx)
+- Concept: [Supplier](../../concepts/access-governance/supplier.mdx)
+- Concept: [Responsibility](../../concepts/access-governance/responsibility.mdx)

--- a/versioned_docs/version-3.1/concepts/access-governance/responsibility.mdx
+++ b/versioned_docs/version-3.1/concepts/access-governance/responsibility.mdx
@@ -1,0 +1,50 @@
+---
+sidebar_position: 6
+---
+
+# Responsibility
+
+## Definition
+
+A **[responsibility](https://build.fhir.org/organization.html)** in Care is a group that gives a person a designation or a duty across Care. A responsibility applies across Care. It does not belong to one facility. For example, you create a responsibility for the people who buy supplies for a region. Each person opens the responsibilities that they belong to from their dashboard.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the responsibility. This attribute is required. |
+| Description | A short explanation of the duty that the group holds. This attribute is optional. |
+| Governance links | The responsibilities that oversee this responsibility, and the responsibilities that this responsibility oversees. |
+
+Note: Only a super administrator creates a responsibility, or changes its name and description.
+
+### Structure
+
+Responsibilities are a flat list. A responsibility has no parent responsibility and no child responsibility. To connect two responsibilities, use the **Governance** section in the detail panel of a responsibility on the **Responsibilities** admin page. The section shows two lists: **Managing Organizations** and **Managed Responsibilities**. Both lists hold responsibilities.
+
+Note: Care uses the word "Governance" in two places. The **Governance** section inside a responsibility links one responsibility to another responsibility. The **Governance** item under **Organizations** in the Admin sidebar holds government organizations. Read [Organisation](../../concepts/access-governance/organization.mdx) for government organizations.
+
+### Roles inside a responsibility
+
+The designation of a person inside a responsibility comes from the roles and permission system. Each role gives the person a set of permissions. Care shows only the roles that apply to a responsibility, such as Admin, Manager, and Member. To learn how roles work, read [Roles and Permission](../../concepts/access-governance/access-control.mdx).
+
+### Access through a governance link
+
+A governance link also gives access. If your role in a responsibility holds the permission Can Manage Connected Role Organizations, Care also shows you the responsibilities that it manages. The Admin role and the Manager role hold this permission.
+
+## Where to find responsibilities
+
+- As a super administrator, open the Admin sidebar. Select **Organizations**. Select **Responsibilities**.
+- To open a responsibility that you belong to, open your dashboard. Select the **Responsibilities** tab.
+- Inside a responsibility, the top of the sidebar shows the responsibilities switcher. The switcher shows the name of the open responsibility and your designation in it. Use the switcher to open another responsibility.
+
+## Related
+
+- Flow: [Create a responsibility](../../flows/access-governance/responsibility/create-responsibility.mdx)
+- Flow: [Add or manage users in a responsibility](../../flows/access-governance/responsibility/manage-responsibility-users.mdx)
+- Flow: [Link responsibilities to each other](../../flows/access-governance/responsibility/link-responsibilities.mdx)
+- Flow: [View your responsibilities](../../flows/access-governance/responsibility/view-your-responsibilities.mdx)
+- Concept: [Roles and Permission](../../concepts/access-governance/access-control.mdx)
+- Concept: [Organisation](../../concepts/access-governance/organization.mdx)
+- Concept: [Supplier](../../concepts/access-governance/supplier.mdx)
+- Concept: [User](../../concepts/access-governance/user.mdx)

--- a/versioned_docs/version-3.1/concepts/access-governance/supplier.mdx
+++ b/versioned_docs/version-3.1/concepts/access-governance/supplier.mdx
@@ -1,0 +1,40 @@
+---
+sidebar_position: 5
+---
+
+# Supplier
+
+## Definition
+
+A **[supplier](https://build.fhir.org/organization.html)** in Care is a vendor or distributor that you order supplies from. Care stores a supplier as one type of organization. Care shows suppliers in their own list, separate from Governance organizations and from Responsibilities.
+
+Suppliers are a flat list. A supplier has no parent organization and no child organizations.
+
+## Where to find it
+
+Select **Organizations** in the Admin sidebar. Then select **Suppliers**. The page shows the heading **Suppliers** and the description **Manage your product suppliers and vendor organizations**. The supplier list is on the left. Select a supplier to see its name and description on the right.
+
+## Key Attributes
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the vendor or distributor. This field is required. |
+| Description | More detail about the supplier. This field is optional. |
+
+### On-screen wording
+
+Care uses one shared organization form for suppliers. The create sheet shows the title **Create Department/Team**. The edit sheet shows the title **Edit Department/Team**. The field hints on the sheet also use department and team wording. The sheet still creates or updates a supplier.
+
+## Use in purchase orders
+
+You select a supplier when you create a purchase order. On the purchase order form, the field is labeled **Vendor/Distributor**. Create the supplier first, then create the purchase order.
+
+## Related
+
+- Flow: [Create a supplier](../../flows/access-governance/supplier/create-supplier.mdx)
+- Flow: [Update a supplier](../../flows/access-governance/supplier/update-supplier.mdx)
+- Concept: [Organisation](../../concepts/access-governance/organization.mdx)
+- Concept: [Responsibility](../../concepts/access-governance/responsibility.mdx)
+- Concept: [Roles and Permission](../../concepts/access-governance/access-control.mdx)
+- Concept: [Purchase Order](../../concepts/supply/purchase-order.mdx)
+- Flow: [Create a purchase order](../../flows/supply/purchase-order/create-purchase-order.mdx)

--- a/versioned_docs/version-3.1/concepts/access-governance/user.mdx
+++ b/versioned_docs/version-3.1/concepts/access-governance/user.mdx
@@ -4,62 +4,59 @@ sidebar_position: 4
 
 # User
 
-A **user** in Care is an account that a person — or an automated integration — uses to sign in and act on the platform. It is the identity behind every action in the record: the doctor who writes a note, the nurse who records an observation, and the operator who registers a patient all do so as a user.
+## Definition
 
-## What it represents
+A **user** in Care is the staff account of a person who works in your organization. Doctors, nurses, and administrators sign in to Care with this account. A user account is separate from a patient record.
 
-In Care's FHIR-aligned model, a user corresponds most closely to the **Practitioner** resource — the person delivering or supporting care. The account captures:
+A user is closest to two FHIR R5 resources. [Practitioner](https://build.fhir.org/practitioner.html) holds the identity of a staff member. [PractitionerRole](https://build.fhir.org/practitionerrole.html) holds the role of a person in an organization. Care does not implement these as literal FHIR resources. The mapping is approximate.
 
-- **Identity** — name (with a prefix such as "Dr."), username, gender, date of birth, and a profile photo
-- **Contact** — the phone number and email used for sign-in and notifications
-- **Credentials** — qualification, medical council registration, and working hours, for staff who provide care
-- **Account context** — the user's geographic organization, who created the account, and whether it is human or automated
+## Key Attributes
 
-A user is not the same as their permissions. The account holds *who someone is*; what they are allowed to do comes from the roles they hold in organizations and facilities — see [Access control](../access-governance/access-control.mdx). Granting or removing a role changes a user's reach without touching their identity, which is why the same account can move between facilities or change duties without being recreated.
+| Components | What it captures |
+| --- | --- |
+| Prefix | The title of the person, for example Dr., Mr., Mrs., Ms., Miss, or Prof. This attribute is optional. |
+| First Name | The first name of the person. This attribute is required. |
+| Last Name | The last name of the person. This attribute is required. |
+| Suffix | The text that comes after the name of the person. This attribute is optional. |
+| Username | The name the person types to sign in. This attribute is required. |
+| Email | The email address of the person. This attribute is required. |
+| Phone Number | The phone number of the person. This attribute is required. |
+| Gender | The gender of the person: Male, Female, Transgender, or Non Binary. This attribute is required. |
+| Government Organization | The government organization of the person. You select it one level at a time, for example State and then District. This attribute is optional. |
 
-## Types
+### Username and Email
 
-Not every account belongs to a person logging in by hand:
+You set the Username and the Email when you create the user. You cannot change them later. Select both values with care.
 
-- **Human accounts** — clinicians and operators who sign in with a username and password, and optionally a one-time code
-- **Service accounts** — machine or integration identities used by other systems to call Care's API on a defined, auditable basis rather than as a person
+### Responsibility Assignments
 
-Both leave the same accountable trail; the distinction matters for how they sign in and for telling automated activity apart from human activity in an audit.
+A user gets access through responsibility assignments. Each assignment joins a Responsibility with a Designation. The designation is the role that the person holds in that responsibility. You can add assignments when you create the user, and you can change them later from the user's profile page. For more information, see [Roles and Permission](../../concepts/access-governance/access-control.mdx).
 
-## How it connects
+### Status
 
-A user is the actor that ties the rest of the record together:
+| Status | Description |
+| --- | --- |
+| Archived | The person cannot sign in to Care. Care keeps the history of the person. The user card shows a grey "Archived" badge. |
 
-- **Authorship** — encounters, observations, orders, and notes record the user who created or updated them, giving every entry an accountable owner
-- **Organization & facility** — a user is granted roles inside [organizations](../access-governance/organization.mdx) and [facilities](../facility/facility.mdx); these memberships decide which patients and data the user can reach
-- **Scheduling** — clinician users back [schedules](../scheduling/schedule.mdx) and [bookings](../scheduling/booking.mdx), so credentials and working hours shape who can be booked
-- **Account creator** — each account records the user who created it, preserving an onboarding trail
+Care shows no status label for an account that is not archived. That person can sign in. Each user card shows one activity badge in place of a status:
 
-## Sign-in and security
+| Badge | Description |
+| --- | --- |
+| Online | The person is active in Care now. |
+| Last sign-in time | The time when the person last signed in, for example "2 days ago". |
+| Never Logged In | The person never signed in to Care. |
+| Service Account | The account is a service account, not a person. |
 
-Care protects accounts with layered sign-in controls:
-
-- **Password** — every human account sets a password that must pass a strength check; service accounts may sign in without one
-- **Multi-factor authentication** — users can enable a time-based one-time code (TOTP) from an authenticator app, with single-use backup codes for recovery
-- **Verification** — accounts carry a verified status, and a user can be reached for a password reset through their registered username
-
-## Permissions
-
-User permissions govern who can create other accounts and assign their roles. They do not control what a user can do clinically — that flows from the roles a user holds. Listing and retrieving user accounts are not gated by a dedicated permission in the viewset, and updating or deleting an account is restricted to the account owner or a superuser rather than to a role permission.
-
-| Permission | Description | System Roles |
-| --- | --- | --- |
-| `can_create_user` | Create a new human user account | Admin, Facility Admin, Administrator |
-| `can_create_service_account` | Create a new service (machine) account | Admin, Facility Admin, Administrator |
-| `can_manage_organization_users` | Assign the requested roles to the new account within an organization | Admin, Administrator, Facility Admin, Admin (role org) |
-| `can_manage_connected_role_organizations` | Assign roles in a connected role organization when onboarding the account | Admin (role org), Manager (role org) |
-
-Roles are granted through organization, facility, and patient memberships, and permissions cascade down the organization tree — a role held at a higher level applies to the facilities and teams beneath it.
+Only a Care superuser can archive an account. Care has no option to reactivate an archived account.
 
 ## Related
 
-- Reference: [User & Skills (technical)](../../references/access-governance/user.mdx)
-- Concept: [Access control](../access-governance/access-control.mdx)
-- Concept: [Organization](../access-governance/organization.mdx)
-- Concept: [Facility](../facility/facility.mdx)
-- Concept: [Patient](../clinical/patient)
+- Flow: [Create a user](../../flows/access-governance/user/create-user.mdx)
+- Flow: [Edit a user's profile](../../flows/access-governance/user/edit-user-profile.mdx)
+- Flow: [Change your password](../../flows/access-governance/user/change-password.mdx)
+- Flow: [Turn on two-factor authentication](../../flows/access-governance/user/turn-on-two-factor-authentication.mdx)
+- Flow: [Deactivate a user account](../../flows/access-governance/user/deactivate-user-account.mdx)
+- Flow: [Search for a user](../../flows/access-governance/user/search-for-user.mdx)
+- Concept: [Roles and Permission](../../concepts/access-governance/access-control.mdx)
+- Concept: [Organisation](../../concepts/access-governance/organization.mdx)
+- Concept: [Responsibility](../../concepts/access-governance/responsibility.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/_category_.json
+++ b/versioned_docs/version-3.1/flows/access-governance/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Access & Governance",
+  "position": 8,
+  "key": "access-governance-flows"
+}

--- a/versioned_docs/version-3.1/flows/access-governance/access-control/_category_.json
+++ b/versioned_docs/version-3.1/flows/access-governance/access-control/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Roles and Permission",
+  "position": 1,
+  "key": "access-governance-access-control-flows"
+}

--- a/versioned_docs/version-3.1/flows/access-governance/access-control/assign-role-to-user.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/access-control/assign-role-to-user.mdx
@@ -1,0 +1,89 @@
+---
+sidebar_position: 4
+---
+
+# Assign a role to a user
+
+## Overview
+
+This flow describes how to link a user to an Organization, a Supplier, a Responsibility, or a Department, and give that user a [role](../../../concepts/access-governance/access-control.mdx). The link and the role together grant the user access.
+
+Note: To create a user account, see [Create a user](../../../flows/access-governance/user/create-user.mdx). This flow covers only the link of a user who already has an account.
+
+## Pre-requisites
+
+- The user that you want to add has a Care account.
+- You have the permissions listed below for the Organization, the Supplier, the Responsibility, or the Department.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Users in an Organization | Lets you add a user, remove a user, or change a user's role in an Organization, a Supplier, or a Responsibility. |
+| Can Manage Users in a Facility Organization | Lets you add a user, remove a user, or change a user's role in a Department. |
+
+## Steps
+
+### 1. Open the Users tab
+
+The screen that you start from depends on the type of the group.
+
+- For an Organization, go to Admin. Select **Organizations**. Select **Governance**. Open the Organization.
+- For a Supplier, go to Admin. Select **Organizations**. Select **Suppliers**. Open the Supplier.
+- For a Responsibility, go to Admin. Select **Organizations**. Select **Responsibilities**. Open the Responsibility.
+- For a Department, open the facility. Select **Settings**. Select **Departments**. Open the Department.
+
+Select the **Users** tab.
+
+### 2. Start the link
+
+Click **Link User**. A sheet opens.
+
+Note: The **Link User** button shows only if you have permission to manage users in that group.
+
+### 3. Find the user
+
+Search for the person in the user picker. Search by name, by username, or by phone number. Select the person from the results.
+
+Care shows the username, the user type, and the phone number of the person that you selected.
+
+### 4. Select the role
+
+Select a role from the **Select Role** list.
+
+The list shows only the roles that match the screen that you are in.
+
+| Screen | Roles in the list |
+| --- | --- |
+| Organization | Government Organization roles |
+| Supplier | Government Organization roles |
+| Responsibility | Responsibility roles |
+| Department | Facility roles |
+
+Note: Care lets you grant only a role with permissions that you also hold. You cannot give a person more access than you have.
+
+### 5. Link the user
+
+For an Organization, a Supplier, or a Responsibility, click **Link to Organization**.
+
+For a Department, click **Add to Organization**.
+
+## Expected Outcome
+
+- Care links the user to the Organization, the Supplier, the Responsibility, or the Department.
+- The Users tab shows the user with the role that you selected.
+- The user gets the permissions of that role for that Organization, Supplier, Responsibility, or Department.
+
+## Related
+
+Concepts:
+
+- [Roles and Permission](../../../concepts/access-governance/access-control.mdx)
+- [Organisation](../../../concepts/access-governance/organization.mdx)
+- [Supplier](../../../concepts/access-governance/supplier.mdx)
+- [Responsibility](../../../concepts/access-governance/responsibility.mdx)
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Change or remove a user's role](./change-or-remove-user-role.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/access-control/change-or-remove-user-role.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/access-control/change-or-remove-user-role.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 5
+---
+
+# Change or remove a user's role
+
+## Overview
+
+This flow describes how to change the [role](../../../concepts/access-governance/access-control.mdx) of a user in an Organization, a Supplier, a Responsibility, or a Department. It also describes how to remove the user from there.
+
+## Pre-requisites
+
+- The user is already linked there. See [Assign a role to a user](./assign-role-to-user.mdx).
+- You have the permissions listed below for the Organization, the Supplier, the Responsibility, or the Department.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Users in an Organization | Lets you change or remove a user's role in an Organization, a Supplier, or a Responsibility. |
+| Can Manage Users in a Facility Organization | Lets you change or remove a user's role in a Department. |
+
+## Steps
+
+### 1. Open the user's card
+
+Go to the Organization, the Supplier, the Responsibility, or the Department.
+
+Select the **Users** tab.
+
+Find the card of the user.
+
+Click **Edit**. Care opens the **Edit User Role** sheet. The sheet shows the username, the current role, and the last login of the user.
+
+Note: Care lets you grant or keep only a role with permissions that you also hold. This rule applies to the current role of the user and to the new role.
+
+### 2. Change the role
+
+In **Select New Role**, choose a different role.
+
+Click **Update Role**.
+
+Note: **Update Role** stays disabled when you choose the same role.
+
+### 3. Remove the user
+
+To remove the user, click **Remove User** in the same sheet.
+
+Care opens the **Remove User from Organization** dialog. Click **Remove** to confirm.
+
+Note: Care keeps the last Facility Admin in the root department of a facility. You cannot change the role of that user. You also cannot remove the last user from the root department.
+
+## Expected Outcome
+
+- The user's card on the Users tab shows the new role.
+- If you removed the user, the Users tab no longer shows the user.
+
+## Related
+
+Concepts:
+
+- [Roles and Permission](../../../concepts/access-governance/access-control.mdx)
+- [Organisation](../../../concepts/access-governance/organization.mdx)
+- [Supplier](../../../concepts/access-governance/supplier.mdx)
+- [Responsibility](../../../concepts/access-governance/responsibility.mdx)
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Assign a role to a user](./assign-role-to-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/access-control/create-role.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/access-control/create-role.mdx
@@ -1,0 +1,75 @@
+---
+sidebar_position: 1
+---
+
+# Create a role
+
+## Overview
+
+This flow describes how to create a new [role](../../../concepts/access-governance/access-control.mdx) in Care. A role groups the permissions that you give to a user.
+
+## Pre-requisites
+
+- You are a super administrator in Care.
+
+## Permissions
+
+Care does not control role management with a permission. Only a super administrator can create a role.
+
+## Steps
+
+### 1. Open the Roles screen
+
+1. Open the Admin sidebar.
+2. Select **RBAC**.
+3. Select **Roles**.
+
+Care shows the list of roles as cards. Use the **Search Roles** box to find a role by name. Use the filter buttons above the list to show one role context.
+
+| Filter | What it shows |
+| --- | --- |
+| All | Every role in Care |
+| Facility | Roles for the Facility context |
+| Government Organization | Roles for the Government Organization context |
+| Responsibility | Roles for the Responsibility context |
+
+### 2. Open the role form
+
+Click **Add Role**. Care opens the role form in a side sheet.
+
+### 3. Complete the role details
+
+Enter the role details in the form.
+
+| Component | What it captures |
+| --- | --- |
+| Name | The name of the role. This field is mandatory. |
+| Description | The purpose of the role. This field is optional. |
+| Contexts | The contexts where the role applies: Facility, Government Organization, or Responsibility. Select one context or more. |
+| Permissions | The permissions that the role gives. Select one permission or more. |
+
+The Permissions list shows all available permissions. Use the **Search permissions** box to find a permission by name. Click **Select All** to select every permission in the list. Click **Clear** to remove your selection.
+
+### 4. Save the role
+
+Click **Create Role**.
+
+To close the form without a new role, click **Cancel**.
+
+## Expected Outcome
+
+- Care shows the message "Role created successfully".
+- Care adds the role to the list of roles.
+- The new role is not a system role. You can edit or clone the role later.
+
+## Related
+
+Concepts:
+
+- [Roles and Permission](../../../concepts/access-governance/access-control.mdx)
+
+Flows:
+
+- [Edit or clone a role](./edit-or-clone-role.mdx)
+- [View the permissions matrix](./view-permissions-matrix.mdx)
+- [Assign a role to a user](./assign-role-to-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/access-control/edit-or-clone-role.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/access-control/edit-or-clone-role.mdx
@@ -1,0 +1,78 @@
+---
+sidebar_position: 2
+---
+
+# Edit or clone a role
+
+## Overview
+
+This flow describes how to change a custom [role](../../../concepts/access-governance/access-control.mdx) in Care. It also describes how to clone a role.
+
+Care includes system roles, such as Doctor. You cannot change a system role. Clone the system role, then adjust the permissions of the copy. The original role stays the same for all other users.
+
+## Pre-requisites
+
+- You are a super administrator in Care.
+- The role that you want to change or clone is in the roles list.
+
+## Permissions
+
+Care does not control role management with a permission. Only a super administrator can edit or clone a role.
+
+## Steps
+
+### 1. Open the roles list
+
+1. Open the Admin sidebar.
+2. Select **RBAC**.
+3. Select **Roles**.
+
+Care shows each role as a card. A system role shows a **System** badge and a lock icon.
+
+### 2. Open the role menu
+
+Click the menu icon on the role card. The menu shows **Edit** and **Clone**.
+
+Note: The menu of a system role shows only **Clone**. You cannot change the name, description, contexts, or permissions of a system role.
+
+### 3. Edit a custom role
+
+1. Select **Edit** on the card of a custom role.
+2. Care opens the role form with the current values.
+3. Change the **Name**, **Description**, **Contexts**, or **Permissions**.
+4. Click **Update Role**.
+
+To close the form without a change, click **Cancel**.
+
+| Component | What it captures |
+| --- | --- |
+| Name | The name of the role. |
+| Description | The purpose of the role. |
+| Contexts | The levels at which the role applies. |
+| Permissions | The actions that the role allows. |
+
+### 4. Clone a role
+
+1. Select **Clone** on the card of any role. You can clone a system role.
+2. Care opens the role form with the contexts and the permissions of the original role.
+3. Care sets the name to "`{original name}` (Copy)".
+4. Change the name and the permissions of the new role.
+5. Click **Create Role**.
+
+## Expected Outcome
+
+- Care saves your changes to the custom role.
+- After a clone, Care adds a new custom role to the roles list. You can edit that role.
+- The original role keeps its name, contexts, and permissions.
+
+## Related
+
+Concepts:
+
+- [Roles and Permission](../../../concepts/access-governance/access-control.mdx)
+
+Flows:
+
+- [Create a role](./create-role.mdx)
+- [View the permissions matrix](./view-permissions-matrix.mdx)
+- [Assign a role to a user](./assign-role-to-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/access-control/view-permissions-matrix.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/access-control/view-permissions-matrix.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 3
+---
+
+# View the permissions matrix
+
+## Overview
+
+This flow describes how to view the permissions matrix in Care. The matrix shows which permissions each [role](../../../concepts/access-governance/access-control.mdx) holds.
+
+## Pre-requisites
+
+- You can open the Admin sidebar in Care.
+
+## Permissions
+
+Care does not control this page with a permission. Every user who opens the Admin sidebar can read the permissions matrix.
+
+## Steps
+
+### 1. Open the Permissions page
+
+1. Open the Admin sidebar.
+2. Select **RBAC**.
+3. Select **Permissions**.
+
+Care shows the permissions matrix.
+
+### 2. Read the matrix
+
+Each row in the table is a permission. Each column is a role.
+
+A green check mark in a cell means that the role holds the permission. A red cross means that the role does not hold the permission.
+
+The table shows 15 roles on a page. Use the pagination control below the table to see more roles.
+
+Note: This page is read-only. You cannot change a permission or a role here.
+
+### 3. Check a role before you grant it
+
+Find the column for the role that you plan to grant.
+
+Read down the column to see every permission that the role allows.
+
+To change the permissions of a role, go to **Roles**. Edit or clone the role there. See [Edit or clone a role](./edit-or-clone-role.mdx).
+
+## Expected Outcome
+
+- You see the full table of permissions and roles.
+- You know which permissions a role allows before you grant that role to a person.
+
+## Related
+
+Concepts:
+
+- [Roles and Permission](../../../concepts/access-governance/access-control.mdx)
+
+Flows:
+
+- [Create a role](./create-role.mdx)
+- [Edit or clone a role](./edit-or-clone-role.mdx)
+- [Assign a role to a user](./assign-role-to-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/organization/_category_.json
+++ b/versioned_docs/version-3.1/flows/access-governance/organization/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Organisation",
+  "position": 2,
+  "key": "access-governance-organization-flows"
+}

--- a/versioned_docs/version-3.1/flows/access-governance/organization/create-organization.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/organization/create-organization.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 1
+---
+
+# Create an organization
+
+## Overview
+
+This flow describes how to create a government [organization](../../../concepts/access-governance/organization.mdx) in Care. You create the organization under a parent organization in the Governance hierarchy.
+
+## Pre-requisites
+
+- You are a Care superuser.
+- The parent organization for the new organization exists in the Governance hierarchy.
+
+## Permissions
+
+Care does not grant this action through a role permission.
+
+| Access | What it allows |
+| --- | --- |
+| Care superuser | Lets you create a government organization at any level of the hierarchy. Care blocks all other users. |
+
+## Steps
+
+### 1. Open the Governance organizations
+
+Select **Organizations** in the Admin sidebar. Then select **Governance**.
+
+Note: The **Governance** item under **Organizations** holds the government organizations. It is not the **Governance** section inside a responsibility.
+
+### 2. Open the parent organization
+
+The left panel shows the organization tree. Select the parent organization for the new organization. Care shows the children of that organization at the right.
+
+Note: Your deployment sets the maximum depth of the organization hierarchy.
+
+### 3. Open the create form
+
+Click **Add Organization**. A sheet opens. The heading of the sheet reads "Create Department/Team". Care uses this same heading for all organization types.
+
+### 4. Enter the organization details
+
+Complete the form fields.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the organization, for example a state name or a district name. Care requires a name. |
+| Description | More detail about the organization. This field is optional. |
+
+Note: The name must be different from the names of the other organizations at the same level of the same hierarchy.
+
+### 5. Submit the form
+
+Click **Create Organization**.
+
+## Expected Outcome
+
+- Care creates the organization under the parent organization that you selected.
+- Care shows the message "Organization created successfully".
+- The new organization shows in the organization tree and in the list of children.
+
+## Related
+
+Concepts:
+
+- [Organisation](../../../concepts/access-governance/organization.mdx)
+
+Flows:
+
+- [Update an organization](./update-organization.mdx)
+- [View the organization hierarchy](./view-organization-hierarchy.mdx)
+- [Delete an organization](./delete-organization.mdx)
+- [Assign a role to a user](../../../flows/access-governance/access-control/assign-role-to-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/organization/delete-organization.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/organization/delete-organization.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 4
+---
+
+# Delete an organization
+
+## Overview
+
+This flow describes how to delete a government [organization](../../../concepts/access-governance/organization.mdx) in Care. Care deletes only an organization that has no child organizations.
+
+## Pre-requisites
+
+- You are a Care superuser.
+- The organization has no child organizations. If the organization has children, delete or move the children first.
+
+## Permissions
+
+Care does not grant this action through a role permission.
+
+| Access | What it allows |
+| --- | --- |
+| Care superuser | Lets you delete a government organization that has no children. Care blocks all other users. |
+
+## Steps
+
+### 1. Open the Governance organizations
+
+Select **Organizations** in the Admin sidebar. Then select **Governance**.
+
+Note: The **Governance** item under **Organizations** holds the government organizations. It is not the **Governance** section inside a responsibility.
+
+### 2. Open the parent organization
+
+Select the parent of the organization in the tree. Care lists the children of that organization at the right.
+
+### 3. Open the menu on the organization card
+
+Find the card of the organization in the list. Click the three-dot menu on that card. Select **Delete**.
+
+Note: Care blocks the deletion when the organization has child organizations. Delete or move the children first.
+
+### 4. Confirm the deletion
+
+Care shows the dialog "Delete Organization". The dialog asks you to confirm the deletion and shows the name of the organization. Click **Delete** to confirm. Click **Cancel** to keep the organization.
+
+## Expected Outcome
+
+- Care deletes the organization.
+- Care shows the message "Organization deleted successfully".
+- The organization no longer shows in the organization tree.
+
+## Related
+
+Concepts:
+
+- [Organisation](../../../concepts/access-governance/organization.mdx)
+
+Flows:
+
+- [Create an organization](./create-organization.mdx)
+- [Update an organization](./update-organization.mdx)
+- [View the organization hierarchy](./view-organization-hierarchy.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/organization/update-organization.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/organization/update-organization.mdx
@@ -1,0 +1,74 @@
+---
+sidebar_position: 2
+---
+
+# Update an organization
+
+## Overview
+
+This flow describes how to change the name and the description of a government [organization](../../../concepts/access-governance/organization.mdx) in Care.
+
+## Pre-requisites
+
+- You are a Care superuser.
+- The organization exists in the Governance hierarchy.
+
+## Permissions
+
+Care does not grant this action through a role permission.
+
+| Access | What it allows |
+| --- | --- |
+| Care superuser | Lets you change the name and the description of a government organization. Care blocks all other users. |
+
+## Steps
+
+### 1. Open the Governance organizations
+
+1. Select **Organizations** in the Admin sidebar.
+2. Select **Governance**.
+
+Note: The **Governance** item under **Organizations** holds the government organizations. It is not the **Governance** section inside a responsibility.
+
+### 2. Open the parent organization
+
+Select the parent of the organization in the tree. Care lists the children of that organization at the right.
+
+### 3. Open the edit form
+
+Find the card of the organization in the list. Click **Edit** on that card. A sheet opens.
+
+Note: The heading of the sheet reads "Edit Department/Team". Care uses this same heading for all organization types.
+
+### 4. Change the details
+
+Enter the new values in the form.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the organization. |
+| Description | More detail about the organization. |
+
+Note: You cannot change the parent of the organization. Use this form only for the name and the description.
+
+### 5. Save the changes
+
+Click **Update Organization**.
+
+## Expected Outcome
+
+- Care saves the new name and the new description of the organization.
+- Care shows the message "Organizations updated successfully".
+- The organization shows the new details in the Governance hierarchy.
+
+## Related
+
+Concepts:
+
+- [Organisation](../../../concepts/access-governance/organization.mdx)
+
+Flows:
+
+- [Create an organization](./create-organization.mdx)
+- [View the organization hierarchy](./view-organization-hierarchy.mdx)
+- [Delete an organization](./delete-organization.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/organization/view-organization-hierarchy.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/organization/view-organization-hierarchy.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_position: 3
+---
+
+# View the organization hierarchy
+
+## Overview
+
+This flow describes how to browse the hierarchy of government [organizations](../../../concepts/access-governance/organization.mdx) in Care. The hierarchy shows each organization and the organizations below it.
+
+## Pre-requisites
+
+- You have access to at least one government organization.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can View Organizations | Lets you see an organization and browse its place in the hierarchy. |
+
+## Steps
+
+### 1. Open the Governance organizations
+
+Select **Organizations** in the Admin sidebar. Then select **Governance**.
+
+Note: The **Governance** item under **Organizations** holds the government organizations. It is not the **Governance** section inside a responsibility.
+
+### 2. Browse the tree
+
+The left panel shows the organizations in a tree, from the top level down. Click the arrow beside an organization to expand its branch. Click the arrow again to collapse the branch.
+
+Note: You see only the organizations that you have access to. Care hides the other organizations.
+
+### 3. Open an organization
+
+Select an organization in the tree. Care shows the name and the description of that organization at the right. Below them, Care lists the child organizations. Care also shows a breadcrumb trail above the name. The breadcrumb trail shows the path from **Organizations** down to the selected organization.
+
+To find a child organization in a long list, enter its name in the search box.
+
+### 4. Browse your own organizations
+
+You can also browse the hierarchy outside the Admin section. Open your dashboard. Select the **Governance** tab. The tab shows the government organizations that you belong to. Select an organization to open it.
+
+Note: The **My Organizations** menu at the top of the sidebar lists the same organizations.
+
+## Expected Outcome
+
+- You see the tree of government organizations that you have access to.
+- You see the breadcrumb trail and the child organizations for the organization that you select.
+
+## Related
+
+Concepts:
+
+- [Organisation](../../../concepts/access-governance/organization.mdx)
+
+Flows:
+
+- [Create an organization](./create-organization.mdx)
+- [Update an organization](./update-organization.mdx)
+- [Delete an organization](./delete-organization.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/responsibility/_category_.json
+++ b/versioned_docs/version-3.1/flows/access-governance/responsibility/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Responsibility",
+  "position": 5,
+  "key": "access-governance-responsibility-flows"
+}

--- a/versioned_docs/version-3.1/flows/access-governance/responsibility/create-responsibility.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/responsibility/create-responsibility.mdx
@@ -1,0 +1,63 @@
+---
+sidebar_position: 1
+---
+
+# Create a responsibility
+
+## Overview
+
+This flow describes how to add a new [responsibility](../../../concepts/access-governance/responsibility.mdx) in Care. Only a super administrator creates a responsibility.
+
+## Pre-requisites
+
+- You are a super administrator in Care. The Admin sidebar opens only for a super administrator.
+
+## Permissions
+
+No permission gives access to this flow. Only a super administrator creates a responsibility.
+
+## Steps
+
+### 1. Open the Responsibilities page
+
+Open the Admin sidebar. Select **Organizations**. Select **Responsibilities**. Care shows the list of responsibilities on the left of the page.
+
+### 2. Start a new responsibility
+
+Click **Create Responsibility**. Care opens the **Create Responsibility** sheet.
+
+### 3. Complete the form
+
+Enter the details in the form.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the responsibility. Required. |
+| Description | A short explanation of the duty that the group holds. Optional. |
+
+### 4. Submit the form
+
+Click **Create Responsibility** in the sheet. The button stays inactive until you enter details in the form. If you leave **Name** empty, Care shows the message "This field is required".
+
+To close the sheet without saving, press **Escape**.
+
+Note: A responsibility has no parent responsibility. Care keeps all responsibilities in one flat list.
+
+Note: To change the name or the description later, select the responsibility. Click **Edit Responsibility**.
+
+## Expected Outcome
+
+- Care shows a message that confirms the new responsibility.
+- The new responsibility shows in the list of responsibilities.
+- Care shows the name and the description of the responsibility in the panel on the right.
+
+## Related
+
+Concepts:
+
+- [Responsibility](../../../concepts/access-governance/responsibility.mdx)
+
+Flows:
+
+- [Add or manage users in a responsibility](./manage-responsibility-users.mdx)
+- [Link responsibilities to each other](./link-responsibilities.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/responsibility/link-responsibilities.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/responsibility/link-responsibilities.mdx
@@ -1,0 +1,80 @@
+---
+sidebar_position: 3
+---
+
+# Link responsibilities to each other
+
+## Overview
+
+This flow describes how to link one [responsibility](../../../concepts/access-governance/responsibility.mdx) to another in Care. A link records which responsibility oversees another responsibility.
+
+## Pre-requisites
+
+- You are a super administrator in Care. The Admin sidebar opens only for a super administrator.
+- Both responsibilities that you want to link exist in Care. See [Create a responsibility](./create-responsibility.mdx).
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Organizations | Lets you link or unlink one responsibility from another. You need this permission on both responsibilities. |
+
+## Steps
+
+### 1. Open the responsibilities list
+
+1. Open the Admin sidebar.
+2. Select **Organizations**.
+3. Select **Responsibilities**.
+
+### 2. Select a responsibility
+
+Select the responsibility that you want to link. Care opens the detail panel for that responsibility.
+
+### 3. Open the Governance section
+
+In the detail panel, go to the **Governance** section.
+
+Note: This **Governance** section links responsibilities to each other. It is not the **Governance** item under **Organizations** in the Admin sidebar, which holds government organizations.
+
+The **Governance** section has two lists:
+
+| List | What it shows |
+| --- | --- |
+| Managing Organizations | The responsibilities that oversee this responsibility. |
+| Managed Responsibilities | The responsibilities that this responsibility oversees. |
+
+### 4. Add a link
+
+1. Go to the list that you want to change.
+2. Open the box below **Add Managing Organization** or **Add Managed Responsibility**.
+3. Enter the name of the other responsibility in the search box.
+4. Select the responsibility from the results.
+5. Click **Add**.
+
+Note: A responsibility cannot manage itself. Care also blocks the same link a second time.
+
+### 5. Remove a link
+
+1. Find the linked responsibility in the list.
+2. Click the **X** icon next to it.
+
+Note: Care shows the **Add** button and the **X** icon only if you can manage the responsibility.
+
+## Expected Outcome
+
+- The **Managing Organizations** list shows each responsibility that oversees this responsibility.
+- The **Managed Responsibilities** list shows each responsibility that this responsibility oversees.
+- Care removes a responsibility from the list after you click the **X** icon.
+
+## Related
+
+Concepts:
+
+- [Responsibility](../../../concepts/access-governance/responsibility.mdx)
+
+Flows:
+
+- [Create a responsibility](./create-responsibility.mdx)
+- [View your responsibilities](./view-your-responsibilities.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/responsibility/manage-responsibility-users.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/responsibility/manage-responsibility-users.mdx
@@ -1,0 +1,85 @@
+---
+sidebar_position: 2
+---
+
+# Add or manage users in a responsibility
+
+## Overview
+
+This flow describes how to add people to a [responsibility](../../../concepts/access-governance/responsibility.mdx) in Care. It also describes how to change or remove the designation of a person.
+
+## Pre-requisites
+
+- A super administrator created the responsibility. See [Create a responsibility](./create-responsibility.mdx).
+- You belong to the responsibility. If you do not belong to it, you belong to a responsibility that manages it. Your role in the managing responsibility holds the permission Can Manage Connected Role Organizations.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can List Users in an Organizations | Lets you open the Users list of the responsibility. |
+| Can Manage Users in an Organization | Lets you link, remove, or change the designation of a person in the responsibility. |
+| Can create User in care | Lets you create a Care account from the Users list. |
+
+## Steps
+
+### 1. Open the responsibility
+
+Open your dashboard. Select the **Responsibilities** tab. Click the card of the responsibility. Care opens the **Users** list of the responsibility.
+
+Note: The **Responsibilities** page in the Admin sidebar does not manage the people in a responsibility. Open the responsibility from your dashboard, or from the responsibilities switcher in the sidebar.
+
+### 2. Read the Users list
+
+The **Users** list shows a card for each person in this responsibility. Each card shows the designation of the person.
+
+To find one person, use the search box. You can search by username or by phone number.
+
+### 3. Link a person who has a Care account
+
+Click **Link User**. Care opens the **Link User to Organization** sheet.
+
+Search for the person. Select the person from the results. Select a designation in **Select Role**. Care shows only the roles that apply to a responsibility.
+
+Click **Link to Organization**.
+
+For the full field-by-field steps, see [Assign a role to a user](../../../flows/access-governance/access-control/assign-role-to-user.mdx).
+
+### 4. Add a person who has no Care account
+
+Click **Add User**. Care opens the **Add New User** sheet. Complete the account details.
+
+In **Responsibility Assignments**, select this responsibility in **Responsibility**. Select a designation in **Designation**. To add more responsibilities for the person, click **Add Another**.
+
+If you skip **Responsibility Assignments**, Care opens the **Link User to Organization** sheet after it creates the account. Then select the designation as described in step 3.
+
+For the account fields, see [Create a user](../../../flows/access-governance/user/create-user.mdx).
+
+### 5. Change or remove a designation
+
+Click **Edit** on the card of the person. Care opens the **Edit User Role** sheet.
+
+To change the designation, select a role in **Select New Role**. Click **Update Role**.
+
+To remove the person from the responsibility, click **Remove User**. Care asks you to confirm. Click **Remove**.
+
+For the full steps, see [Change or remove a user's role](../../../flows/access-governance/access-control/change-or-remove-user-role.mdx).
+
+## Expected Outcome
+
+- The **Users** list shows the person with the designation that you selected.
+- The person gets the permissions of that role inside this responsibility.
+- If you remove a person, the **Users** list no longer shows that person.
+
+## Related
+
+Concepts:
+
+- [Responsibility](../../../concepts/access-governance/responsibility.mdx)
+
+Flows:
+
+- [Create a responsibility](./create-responsibility.mdx)
+- [Assign a role to a user](../../../flows/access-governance/access-control/assign-role-to-user.mdx)
+- [Change or remove a user's role](../../../flows/access-governance/access-control/change-or-remove-user-role.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/responsibility/view-your-responsibilities.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/responsibility/view-your-responsibilities.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 4
+---
+
+# View your responsibilities
+
+## Overview
+
+This flow describes how to open the [responsibilities](../../../concepts/access-governance/responsibility.mdx) that you belong to from your dashboard in Care.
+
+## Pre-requisites
+
+- You belong to at least one responsibility. See [Add or manage users in a responsibility](./manage-responsibility-users.mdx).
+
+## Permissions
+
+You need no extra permission to see this tab. If your role in a responsibility holds the permission Can Manage Connected Role Organizations, Care also shows the responsibilities that it manages.
+
+## Steps
+
+### 1. Open the Responsibilities tab
+
+Open your dashboard. The dashboard shows the **Responsibilities** tab beside the **Facilities** tab and the **Governance** tab.
+
+Note: The **Responsibilities** tab shows only when Care finds at least one responsibility for you.
+
+Note: The **Governance** tab holds government organizations. It is a different feature from the **Governance** section that links responsibilities to each other.
+
+Select **Responsibilities**. Care shows a card for each responsibility that you can open.
+
+Note: This view shows the responsibilities that you belong to. It also shows the responsibilities that your responsibility manages. You cannot search for other responsibilities here.
+
+### 2. Read your designation on the card
+
+Each card shows the name of the responsibility. The subtitle on the card shows your designation in that responsibility. A card shows no subtitle if you do not belong to that responsibility.
+
+### 3. Open a responsibility
+
+Click the card of the responsibility that you want to open.
+
+Care opens the **Users** list of the responsibility. If your permissions in that responsibility do not let you view users, Care opens the **Patients** list instead.
+
+### 4. Move to another responsibility
+
+Inside a responsibility, the top of the sidebar shows the responsibilities switcher. The switcher shows the name of the open responsibility and your designation in it.
+
+Select another responsibility in the switcher to open it. To go back to your dashboard, select **View Dashboard** in the switcher.
+
+## Expected Outcome
+
+- You see each responsibility that you can open, with your designation in it.
+- Care opens the responsibility that you select, and shows its **Users** list or its **Patients** list.
+- The sidebar lets you move between your responsibilities.
+
+## Related
+
+Concepts:
+
+- [Responsibility](../../../concepts/access-governance/responsibility.mdx)
+
+Flows:
+
+- [Add or manage users in a responsibility](./manage-responsibility-users.mdx)
+- [Link responsibilities to each other](./link-responsibilities.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/supplier/_category_.json
+++ b/versioned_docs/version-3.1/flows/access-governance/supplier/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Supplier",
+  "position": 4,
+  "key": "access-governance-supplier-flows"
+}

--- a/versioned_docs/version-3.1/flows/access-governance/supplier/create-supplier.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/supplier/create-supplier.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 1
+---
+
+# Create a supplier
+
+## Overview
+
+This flow describes how to add a new [supplier](../../../concepts/access-governance/supplier.mdx) in Care. After you create the supplier, you can select it as the vendor on a purchase order.
+
+## Pre-requisites
+
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Create Organizations | Lets you add a new organization. |
+
+Note: A supplier has no parent organization. Care lets only a super administrator create an organization that has no parent. Ask your super administrator to add the supplier.
+
+## Steps
+
+### 1. Open the Suppliers list
+
+Open the Admin sidebar. Select **Organizations**. Select **Suppliers**.
+
+### 2. Start a new supplier
+
+Click **Add Organization**. Care opens a sheet with the title **Create Department/Team**. Care uses this title for all organization types.
+
+### 3. Complete the form
+
+Enter the supplier details.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The supplier's or vendor's name. Required. |
+| Description | Extra detail about the supplier. Optional. |
+
+Note: The field hints on this sheet also use department and team wording.
+
+### 4. Submit the form
+
+Click **Create Organization**. To close the sheet without saving, press Escape.
+
+## Expected Outcome
+
+- Care shows the message **Organization created successfully**.
+- The supplier shows in the Suppliers list.
+- You can select the supplier as the **Vendor/Distributor** when you create a purchase order.
+
+## Related
+
+Concepts:
+
+- [Supplier](../../../concepts/access-governance/supplier.mdx)
+
+Flows:
+
+- [Update a supplier](./update-supplier.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/supplier/update-supplier.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/supplier/update-supplier.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 2
+---
+
+# Update a supplier
+
+## Overview
+
+This flow describes how to change the name and the description of a [supplier](../../../concepts/access-governance/supplier.mdx) in Care.
+
+## Pre-requisites
+
+- The supplier is in the Suppliers list.
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can Manage Organizations | Lets you change a supplier's name and description. |
+
+## Steps
+
+### 1. Open the Suppliers list
+
+Open the Admin sidebar. Select **Organizations**. Select **Suppliers**.
+
+### 2. Select the supplier
+
+Select the supplier that you want to change from the list. Care shows the supplier name and description on the right.
+
+### 3. Open the edit form
+
+Click **Edit** next to the supplier name. Care opens a sheet with the title **Edit Department/Team**. Care uses this title for suppliers also.
+
+### 4. Change the supplier details
+
+Change the fields that you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Name | The name of the supplier. |
+| Description | More information about the supplier. |
+
+### 5. Save the changes
+
+Click **Update Organization**. Care saves the new name and description.
+
+Note: Care keeps **Update Organization** disabled until you change a field.
+
+Note: To close the sheet without saving, press Escape.
+
+## Expected Outcome
+
+- Care shows the message **Organizations updated successfully**.
+- Care shows the supplier with the new name and description.
+
+## Related
+
+Concepts:
+
+- [Supplier](../../../concepts/access-governance/supplier.mdx)
+
+Flows:
+
+- [Create a supplier](./create-supplier.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/user/_category_.json
+++ b/versioned_docs/version-3.1/flows/access-governance/user/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "User",
+  "position": 3,
+  "key": "access-governance-user-flows"
+}

--- a/versioned_docs/version-3.1/flows/access-governance/user/change-password.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/user/change-password.mdx
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+---
+
+# Change your password
+
+## Overview
+
+This flow describes how you change your own password in Care. It covers a change from your [user](../../../concepts/access-governance/user.mdx) profile, and a reset when you forget your password.
+
+Note: Care has no option for an administrator to reset the password of another user. Only the owner of the account changes or resets a password.
+
+## Pre-requisites
+
+- If you change your password from your profile, you are signed in as yourself.
+- If you reset a forgotten password by email, you know your username.
+- If you reset a forgotten password by phone, you know the phone number on your account.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| None. Care lets the owner of the account change the password. | Lets you change or reset your own password. |
+
+## Steps
+
+### A. Change your password when you are signed in
+
+#### 1. Open your profile page
+
+Go to your profile page. The **Reset Password** section shows only on your own profile.
+
+Note: You cannot change the password of another user from their profile.
+
+#### 2. Open the password form
+
+Click **Update Password**.
+
+#### 3. Enter your passwords
+
+Complete the fields in the form.
+
+| Components | What it captures |
+| --- | --- |
+| Current Password | Your current password. |
+| New Password | Your new password. It must have at least 8 characters, one upper case letter, one lower case letter, and one digit. It must be different from the current password. |
+| Confirm New Password | The new password again. It must match the New Password. |
+
+Note: Care shows a checklist below **New Password**. Each rule turns green when the new password agrees with that rule.
+
+#### 4. Save the new password
+
+Click **Update Password**. To stop the change, click **Cancel**.
+
+### B. Reset a forgotten password before you sign in
+
+#### 5. Request a reset link
+
+Go to the sign-in page. Click **Forgot password?**. Enter your username. Click **Send Reset Link**.
+
+Note: Care sends the email only if the username exists. The screen shows the same message for a username that does not exist.
+
+Note: If you cannot open your email, click **Can't access your email?**, then **Reset using phone number**. Care sends a one-time password to the phone number on your account.
+
+#### 6. Open the link in your email
+
+Care sends an email with a link to set a new password. Open the link.
+
+Note: The link expires after a set number of hours. Your deployment configures this period.
+
+#### 7. Set your new password
+
+Enter your new password. Confirm the new password. Click **Reset**.
+
+## Expected Outcome
+
+- Care updates your password.
+- Care shows the message "Password updated successfully" for a change from your profile.
+- Care shows the message "Password Reset successfully" for a reset from the sign-in page.
+- You sign in with your new password.
+
+## Related
+
+Concepts:
+
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Edit a user's profile](./edit-user-profile.mdx)
+- [Turn on two-factor authentication](./turn-on-two-factor-authentication.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/user/create-user.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/user/create-user.mdx
@@ -1,0 +1,85 @@
+---
+sidebar_position: 1
+---
+
+# Create a user
+
+## Overview
+
+This flow describes how to create a new [user](../../../concepts/access-governance/user.mdx) account in Care. You create the user from the **Users** tab of an organization, a responsibility, or a department.
+
+## Pre-requisites
+
+- You have the permission listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can create User in care | Lets you create a new user account. |
+
+## Steps
+
+### 1. Open the Users tab
+
+Open the **Users** tab of an organization, a responsibility, or a department.
+
+- For an organization or a responsibility, go to Admin, then Organizations. Select Governance, Suppliers, or Responsibilities. Select one item, then open **Users**.
+- For a department, go to the facility, then Settings, then Departments. Select one department, then open **Users**.
+
+### 2. Open the new user form
+
+Click **Add User**. Care opens the **Add New User** panel.
+
+### 3. Complete the user details
+
+Enter the details of the person.
+
+| Components | What it captures |
+| --- | --- |
+| Prefix | An optional title, for example Dr., Mr., Mrs., Ms., Miss, or Prof. |
+| First Name | The person's first name. Required. |
+| Last Name | The person's last name. Required. |
+| Suffix | An optional suffix after the name. |
+| Username | A unique sign-in name, 4 to 16 characters, lowercase letters, numbers, underscore, or hyphen. Required, and you cannot change it later. Care checks that the name is available as you type. |
+| Email | The person's email address. Required, and you cannot change it later. |
+| Password Setup Method | Select **Set password now** to set a password immediately. Select **Send email invitation** to email the person a link to set their own password. |
+| Password / Confirm Password | Required only if you select **Set password now**. At least 8 characters, with an upper case letter, a lower case letter, and a digit. |
+| Phone Number | The person's phone number. Required. |
+| Gender | Male, Female, Transgender, or Non Binary. Required. |
+| Responsibility Assignments | One or more pairs of **Responsibility** and **Designation**. Care links the new user to each responsibility that you add. Optional. |
+| Government organization | The government organization of the person. Select it one level at a time, for example State and then District. Optional. |
+
+Note: The default country setting of your deployment controls the phone number format on this screen.
+
+Note: Care lists each responsibility one time only. Click **Add Another** to add one more pair.
+
+### 4. Create the user
+
+Click **Create User**. Care creates the account and shows a confirmation message.
+
+If you select **Send email invitation**, Care emails the person a link to set up the password.
+
+### 5. Link the user
+
+If you work in a responsibility, and you already added a responsibility assignment for that responsibility, Care skips this step.
+
+In all other conditions, Care opens the **Link User** panel. Assign the role of the new user in this panel. See [Assign a role to a user](../../../flows/access-governance/access-control/assign-role-to-user.mdx).
+
+## Expected Outcome
+
+- Care creates the user account.
+- Care shows the message "User added successfully".
+- The person receives an email with a link to set up the password, if you select **Send email invitation**.
+- Care links the user to the responsibilities and designations that you select.
+
+## Related
+
+Concepts:
+
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Edit a user's profile](./edit-user-profile.mdx)
+- [Assign a role to a user](../../../flows/access-governance/access-control/assign-role-to-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/user/deactivate-user-account.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/user/deactivate-user-account.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 5
+---
+
+# Deactivate a user account
+
+## Overview
+
+This flow describes how to deactivate a [user](../../../concepts/access-governance/user.mdx) account in Care. Care archives the account, or removes it, and the person can no longer sign in. Care names this action **Delete Account**.
+
+## Pre-requisites
+
+- You are a Care superuser.
+- You know which user account to deactivate.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| None. Care lets a superuser deactivate a user account. | Lets you deactivate this user account. |
+
+## Steps
+
+### 1. Open the user profile
+
+Open the profile page of the user account to deactivate.
+
+Note: Only a Care superuser can deactivate an account. No other role can do this. A user who is not a superuser cannot deactivate their own account.
+
+### 2. Find the Danger Zone card
+
+Go to the bottom of the profile page. Find the **Danger Zone** card. The card holds the **Delete Account** action.
+
+Note: The **Danger Zone** card shows only to a Care superuser.
+
+### 3. Start the deactivation
+
+Click **Delete Account**. Care opens the **Verify Account Deletion request** dialog.
+
+### 4. Confirm the deactivation
+
+Type **Delete Account** in the box. Type the text exactly. Care keeps the action button inactive until the text agrees.
+
+Click **Delete Account** to deactivate the account. On your own profile, the button reads **Delete My Account**.
+
+Note: Click **Cancel** to stop the action.
+
+## Expected Outcome
+
+- Care shows the message "User Deleted Successfully".
+- If the account signed in one time or more before, Care keeps its history and marks the account "Archived".
+- If the account never signed in, Care removes the account.
+- The card of an archived account shows a grey "Archived" badge in place of **See Details**.
+- The user of an archived account can no longer sign in.
+
+Note: Care has no option in the interface to reactivate an archived account.
+
+## Related
+
+Concepts:
+
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Create a user](./create-user.mdx)
+- [Search for a user](./search-for-user.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/user/edit-user-profile.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/user/edit-user-profile.mdx
@@ -1,0 +1,75 @@
+---
+sidebar_position: 2
+---
+
+# Edit a user's profile
+
+## Overview
+
+This flow describes how to change the profile details of a [user](../../../concepts/access-governance/user.mdx) in Care. You can edit your own profile, or any profile if you are a Care superuser.
+
+## Pre-requisites
+
+- You view your own profile, or you are a Care superuser.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| None. Care lets a superuser, or the owner of the account, edit the profile. | Lets you edit this profile. |
+
+## Steps
+
+### 1. Open the user's profile page
+
+Search for the user, then click **See Details** on the card of the user. To open your own profile, select your name in the sidebar.
+
+The profile page opens on the **User Information** tab.
+
+Note: The **Departments** tab shows only when you open the profile from a facility. The **Availability** tab shows only when you open the profile from a facility, and you have permission to view schedules.
+
+### 2. Click Edit User
+
+Click **Edit User**. Care opens the **Edit User** panel.
+
+Note: **Edit User** shows only to a Care superuser, or to the user who views their own profile.
+
+### 3. Change the profile details
+
+Change the fields you want to update.
+
+| Components | What it captures |
+| --- | --- |
+| Prefix | The title before the name, for example Dr. |
+| First Name | The given name of the user. |
+| Last Name | The family name of the user. |
+| Suffix | The title after the name. |
+| Phone Number | The contact number of the user. |
+| Gender | The gender of the user. |
+| Government organization | The government organization of the user. Select it one level at a time, for example State and then District. |
+
+Note: You cannot change the username or the email address from this panel.
+
+Note: To change the responsibilities and designations of the user, use **Manage Assignments** in the **Responsibility Assignments** section of the profile page. See [Change or remove a user's role](../../../flows/access-governance/access-control/change-or-remove-user-role.mdx).
+
+### 4. Save the changes
+
+Click **Update User**. Care saves the changes and closes the panel.
+
+Note: **Update User** stays inactive until you change one field or more.
+
+## Expected Outcome
+
+- Care shows the message "User updated successfully".
+- The profile page shows the updated details on the **User Information** tab.
+
+## Related
+
+Concepts:
+
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Create a user](./create-user.mdx)
+- [Change your password](./change-password.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/user/search-for-user.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/user/search-for-user.mdx
@@ -1,0 +1,65 @@
+---
+sidebar_position: 6
+---
+
+# Search for a user
+
+## Overview
+
+This flow describes how to find a [user](../../../concepts/access-governance/user.mdx) in Care. You can search inside an organization, a responsibility, or a department. You can also search the users list of a facility.
+
+## Pre-requisites
+
+- You are signed in to Care.
+- You have the permissions listed below.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| Can list Users in Care | Lets you search for and view user accounts. |
+
+Note: Every signed-in user can search for and view the basic profile of any other user. Care does not limit the results to the people you work with.
+
+## Steps
+
+### 1. Search inside an organization, a responsibility, or a department
+
+1. Open the organization, the responsibility, or the department.
+2. Select the **Users** tab.
+3. Select **Username** or **Phone Number** in the search box.
+4. Enter the username or the phone number. Care shows the matching users as a grid of cards.
+5. Read the card to see the designation of the user in that organization, responsibility, or department.
+6. Use the pagination controls to see more results.
+
+### 2. Search the users of a facility
+
+1. Open the facility.
+2. Select **Users**. Care opens the **Users Management** page.
+3. Enter a username in the search box.
+
+   Note: This page accepts a username only. It does not accept a phone number.
+
+4. Care shows all users who have access to the facility.
+5. Select **Card** or **List** to change the view.
+
+Note: You can only read the facility users list. You cannot change a user from this list.
+
+Note: Press `Cmd` + `K` to move the cursor to the search box. On Windows and Linux, press `Ctrl` + `K`.
+
+## Expected Outcome
+
+- Care shows the users that match your search.
+- You click **See Details** on a card to open the profile of that user.
+- The card of an archived user shows an "Archived" badge in place of **See Details**.
+
+## Related
+
+Concepts:
+
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Create a user](./create-user.mdx)
+- [Deactivate a user account](./deactivate-user-account.mdx)

--- a/versioned_docs/version-3.1/flows/access-governance/user/turn-on-two-factor-authentication.mdx
+++ b/versioned_docs/version-3.1/flows/access-governance/user/turn-on-two-factor-authentication.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 4
+---
+
+# Turn on two-factor authentication
+
+## Overview
+
+This flow describes how you add two-factor authentication to your own [user](../../../concepts/access-governance/user.mdx) account in Care. Two-factor authentication uses a time-based one-time password from an authenticator app.
+
+## Pre-requisites
+
+- You are signed in as yourself.
+- You have an authenticator app on your phone or device, for example Google Authenticator, Microsoft Authenticator, or Duo Mobile.
+- You know your current password.
+
+Note: Two-factor authentication is a self-service setting. You turn it on for your own account only. An administrator cannot turn it on for another person.
+
+## Permissions
+
+| Permission | Access |
+| --- | --- |
+| None. Care lets the owner of the account manage this setting. | Lets you turn two-factor authentication on or off for your own account. |
+
+## Steps
+
+### 1. Open the security settings
+
+Go to your profile page. Find the **Two Factor Authentication** card. Click **Enable two-factor authentication**.
+
+Note: The **Two Factor Authentication** card shows only on your own profile.
+
+### 2. Confirm your password
+
+Care opens the **Confirm Password** dialog. Enter your current password. Click **Continue**.
+
+### 3. Scan the QR code
+
+Care shows a QR code. Open your authenticator app. Scan the QR code with the app.
+
+Note: If you cannot scan the code, click **Copy setup key** below the QR code. Care shows the secret key and copies it. Enter the key in your authenticator app.
+
+### 4. Verify the setup
+
+Your authenticator app generates a 6-digit code. Enter the code in **Enter the verification code**. Click **Verify Code**.
+
+### 5. Save your backup codes
+
+Care shows a set of backup codes. Click **Copy**, **Download**, or **Print** to keep the codes. Save the codes in a safe place. If you lose access to your authenticator app, use a backup code to sign in.
+
+Click **Done** to close the dialog.
+
+Note: To replace the codes later, click **Regenerate backup codes** on the **Two Factor Authentication** card. Enter your current password. Click **Regenerate**. Care shows new codes. The old codes stop working.
+
+### 6. Turn off two-factor authentication
+
+Do this step only when you want to remove two-factor authentication.
+
+1. Go to the **Two Factor Authentication** card on your profile page.
+2. Click **Disable 2FA**.
+3. Enter your current password in the **Disable two-factor authentication** dialog.
+4. Click **Confirm**.
+
+## Expected Outcome
+
+- Care turns on two-factor authentication for your account.
+- The **Two Factor Authentication** card reads "Two-factor authentication is currently active on your account."
+- Care asks for a 6-digit code from your authenticator app each time you sign in.
+- You hold a set of backup codes for the times when your authenticator app is not available.
+
+## Related
+
+Concepts:
+
+- [User](../../../concepts/access-governance/user.mdx)
+
+Flows:
+
+- [Change your password](./change-password.mdx)

--- a/versioned_sidebars/version-3.1-sidebars.json
+++ b/versioned_sidebars/version-3.1-sidebars.json
@@ -422,6 +422,69 @@
         },
         {
           "type": "category",
+          "label": "Access & Governance",
+          "key": "access-governance-flows",
+          "items": [
+            {
+              "type": "category",
+              "label": "Roles and Permission",
+              "key": "access-governance-access-control-flows",
+              "items": [
+                "flows/access-governance/access-control/create-role",
+                "flows/access-governance/access-control/edit-or-clone-role",
+                "flows/access-governance/access-control/view-permissions-matrix",
+                "flows/access-governance/access-control/assign-role-to-user",
+                "flows/access-governance/access-control/change-or-remove-user-role"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Organisation",
+              "key": "access-governance-organization-flows",
+              "items": [
+                "flows/access-governance/organization/create-organization",
+                "flows/access-governance/organization/update-organization",
+                "flows/access-governance/organization/view-organization-hierarchy",
+                "flows/access-governance/organization/delete-organization"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "User",
+              "key": "access-governance-user-flows",
+              "items": [
+                "flows/access-governance/user/create-user",
+                "flows/access-governance/user/edit-user-profile",
+                "flows/access-governance/user/change-password",
+                "flows/access-governance/user/turn-on-two-factor-authentication",
+                "flows/access-governance/user/deactivate-user-account",
+                "flows/access-governance/user/search-for-user"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Supplier",
+              "key": "access-governance-supplier-flows",
+              "items": [
+                "flows/access-governance/supplier/create-supplier",
+                "flows/access-governance/supplier/update-supplier"
+              ]
+            },
+            {
+              "type": "category",
+              "label": "Responsibility",
+              "key": "access-governance-responsibility-flows",
+              "items": [
+                "flows/access-governance/responsibility/create-responsibility",
+                "flows/access-governance/responsibility/manage-responsibility-users",
+                "flows/access-governance/responsibility/link-responsibilities",
+                "flows/access-governance/responsibility/view-your-responsibilities"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "category",
           "label": "Platform",
           "key": "platform-flows",
           "items": [


### PR DESCRIPTION
## What

Publishes the five **Roles & Governance** modules from `care_docs` into the docs site (version 3.1). 21 flows, 3 refreshed concepts and 2 new ones.

| Module | Flows | Concept |
| --- | --- | --- |
| Roles and Permission | 5 | replaces `access-control.mdx` |
| Organisation | 4 | replaces `organization.mdx` |
| User | 6 | replaces `user.mdx` |
| Supplier | 2 | **new** |
| Responsibility | 4 | **new** |

Adds an `Access & Governance` category to the 3.1 flows sidebar with the five modules nested under it.

## Module mapping

All five publish under the existing `access-governance` domain. `Roles and Permission` maps to `access-control.mdx`, which is already titled "Roles & Permissions" and covers the same subject.

Supplier and Responsibility are new concepts. Both are modelled as organization types in Care but are shown as their own lists in the product, so they get their own pages.

## Frontmatter

None of these files had publishing frontmatter, so `domain`, `module` and `sidebar_position` were added to the five concepts and a `slug` plus `sidebar_position` to all twenty-one flows. Flow titles were converted from "How to Create a Role" to "Create a role".

## Concept titles

Two existing pages change title, since the authored title is published as written:

| Was | Now |
| --- | --- |
| Roles & Permissions | Roles and Permission |
| Organization | Organisation |

Note the spelling shift to "Organisation" on the concept page while the route, the module folder and the flow titles stay "organization". Flag if that should be unified.

## Verification

Docusaurus build passes for both `en` and `ml` locales.
